### PR TITLE
feat: generalize simulation to all wallets

### DIFF
--- a/manta-pay/src/simulation/ledger/mod.rs
+++ b/manta-pay/src/simulation/ledger/mod.rs
@@ -16,6 +16,9 @@
 
 //! Ledger Simulation
 
+// TODO: How to model existential deposits and fee payments?
+// TODO: Add in some concurrency (and measure how much we need it).
+
 use crate::{
     config::{
         Config, EncryptedNote, MerkleTreeConfiguration, MultiVerifyingContext, ProofSystem,


### PR DESCRIPTION
Generalizes simulation for all wallets of the form `Wallet<C, L, S>` for where `C` is the transfer configuration, `L` is the ledger connection, and `S` is the signer connection. This allows for testing with more interaction complexity like substrate in-memory ledger, full node ledger, full signer, etc.

To build your own simulation see how the `manta-pay/src/simulation/mod.rs` file runs the new generalized simulation and copy the overall pattern.