### PR TITLE
Generalize Wallets and Fix Receiving Key Encoding

### DIFF
--- a/manta-pay/Cargo.toml
+++ b/manta-pay/Cargo.toml
@@ -62,7 +62,7 @@ http = ["futures", "reqwest", "serde"]
 scale = ["scale-codec", "scale-info"]
 
 # Serde
-serde = ["bs58", "manta-accounting/serde", "manta-crypto/serde", "serde_json"]
+serde = ["manta-accounting/serde", "manta-crypto/serde"]
 
 # Simulation Framework
 simulation = [
@@ -84,7 +84,7 @@ test = ["manta-accounting/test", "manta-crypto/test"]
 wallet = ["bip32", "manta-crypto/getrandom", "std"]
 
 # Enable WebSocket Signer Client
-websocket = ["serde", "std", "tungstenite"]
+websocket = ["serde", "serde_json", "std", "tungstenite"]
 
 [dependencies]
 aes-gcm = { version = "0.9.4", default-features = false, features = ["aes", "alloc"] }

--- a/manta-pay/src/crypto/ecc/arkworks.rs
+++ b/manta-pay/src/crypto/ecc/arkworks.rs
@@ -268,7 +268,7 @@ where
 
 /// Converts `point` into its canonical byte-representation.
 #[inline]
-fn affine_point_as_bytes<C>(point: &C::Affine) -> Vec<u8>
+pub fn affine_point_as_bytes<C>(point: &C::Affine) -> Vec<u8>
 where
     C: ProjectiveCurve,
 {

--- a/manta-pay/src/simulation/ledger/mod.rs
+++ b/manta-pay/src/simulation/ledger/mod.rs
@@ -16,6 +16,9 @@
 
 //! Ledger Simulation
 
+// TODO: How to model existential deposits and fee payments?
+// TODO: Add in some concurrency (and measure how much we need it).
+
 use crate::{
     config::{
         Config, EncryptedNote, MerkleTreeConfiguration, MultiVerifyingContext, ProofSystem,


### PR DESCRIPTION
Generalizes simulation for all wallets of the form `Wallet<C, L, S>` for where `C` is the transfer configuration, `L` is the ledger connection, and `S` is the signer connection. This allows for testing with more interaction complexity like substrate in-memory ledger, full node ledger, full signer, etc. To build your own simulation see how the `manta-pay/src/simulation/mod.rs` file runs the new generalized simulation and copy the overall pattern.

The receiving key encoding is the following:

```text
ReceivingKey { spend: G, view: G } => x-coordinates: [u8;32] + [u8;32] => [u8;64] => base58 ~88 characters
```