### PR TITLE
Support scalar mul of arkworks curve using precomputed table

### DIFF
--- a/manta-crypto/src/ecc.rs
+++ b/manta-crypto/src/ecc.rs
@@ -165,7 +165,9 @@ where
 /// Elliptic Curve Group
 pub trait Group<COM = ()>: PointAdd<COM> + PointDouble<COM> + ScalarMul<COM> {}
 
-/// Pre-processed Scalar Multiplication Table, represented as powers of two of `scalar`.
+/// Pre-processed Scalar Multiplication Table.
+///
+/// This table contains power-of-two multiples of a fixed base group element.
 #[cfg_attr(
     feature = "serde",
     derive(Deserialize, Serialize),

--- a/manta-crypto/src/ecc.rs
+++ b/manta-crypto/src/ecc.rs
@@ -145,20 +145,6 @@ pub trait PreprocessedScalarMul<COM, const N: usize>: ScalarMul<COM> + Sized {
     ) -> Self::Output;
 }
 
-impl<G, COM> PreprocessedScalarMul<COM, 1> for G
-where
-    G: ScalarMul<COM>,
-{
-    #[inline]
-    fn preprocessed_scalar_mul(
-        table: &[Self; 1],
-        scalar: &Self::Scalar,
-        compiler: &mut COM,
-    ) -> Self::Output {
-        table[0].scalar_mul(scalar, compiler)
-    }
-}
-
 /// Elliptic Curve Group
 pub trait Group<COM = ()>: PointAdd<COM> + PointDouble<COM> + ScalarMul<COM> {}
 

--- a/manta-crypto/src/ecc.rs
+++ b/manta-crypto/src/ecc.rs
@@ -137,12 +137,29 @@ pub trait ScalarMul<COM = ()> {
 /// Elliptic Curve Pre-processed Scalar Multiplication Operation
 pub trait PreprocessedScalarMul<COM, const N: usize>: ScalarMul<COM> + Sized {
     /// Performs the scalar multiplication against a pre-computed table.
+    ///
+    /// The pre-computed table is a list of power-of-two multiples of `scalar`, such that
+    /// `table[i] = scalar * 2^i`.
     #[must_use]
     fn preprocessed_scalar_mul(
         table: &[Self; N],
         scalar: &Self::Scalar,
         compiler: &mut COM,
     ) -> Self::Output;
+}
+
+impl<G, COM> PreprocessedScalarMul<COM, 1> for G
+where
+    G: ScalarMul<COM>,
+{
+    #[inline]
+    fn preprocessed_scalar_mul(
+        table: &[Self; 1],
+        scalar: &Self::Scalar,
+        compiler: &mut COM,
+    ) -> Self::Output {
+        table[0].scalar_mul(scalar, compiler)
+    }
 }
 
 /// Elliptic Curve Group

--- a/manta-pay/Cargo.toml
+++ b/manta-pay/Cargo.toml
@@ -78,7 +78,7 @@ simulation = [
 std = ["manta-accounting/std", "manta-util/std"]
 
 # Testing Frameworks
-test = ["manta-accounting/test", "manta-crypto/test"]
+test = ["manta-accounting/test", "manta-crypto/test", "manta-crypto/getrandom"]
 
 # Wallet
 wallet = ["bip32", "manta-crypto/getrandom", "std"]

--- a/manta-pay/Cargo.toml
+++ b/manta-pay/Cargo.toml
@@ -78,7 +78,7 @@ simulation = [
 std = ["manta-accounting/std", "manta-util/std"]
 
 # Testing Frameworks
-test = ["manta-accounting/test", "manta-crypto/test", "manta-crypto/getrandom"]
+test = ["manta-accounting/test", "manta-crypto/test"]
 
 # Wallet
 wallet = ["bip32", "manta-crypto/getrandom", "std"]
@@ -120,3 +120,4 @@ tungstenite = { version = "0.17.2", optional = true, default-features = false, f
 
 [dev-dependencies]
 manta-pay = { path = ".", features = ["groth16", "test"] }
+manta-crypto = { path = "../manta-crypto", default-features = false, features = ["getrandom"] }

--- a/manta-pay/src/crypto/constraint/arkworks/mod.rs
+++ b/manta-pay/src/crypto/constraint/arkworks/mod.rs
@@ -276,6 +276,14 @@ where
         cs.set_optimization_goal(ark_r1cs::OptimizationGoal::Constraints);
         Self { cs }
     }
+
+    /// Check if all constraints are satisfied.
+    #[inline]
+    pub fn is_satisfied(&self) -> bool {
+        self.cs
+            .is_satisfied()
+            .expect("is_satisfied is not allowed to fail")
+    }
 }
 
 impl<F> ConstraintSystem for R1CS<F>

--- a/manta-pay/src/crypto/ecc/arkworks.rs
+++ b/manta-pay/src/crypto/ecc/arkworks.rs
@@ -572,11 +572,12 @@ where
 mod tests {
     use super::*;
     use ark_ec::ProjectiveCurve;
-    use ark_ed_on_bls12_381::constraints::EdwardsVar;
-    use ark_ed_on_bls12_381::EdwardsProjective;
-    use manta_crypto::constraint::ConstraintSystem;
-    use manta_crypto::ecc::{PreprocessedScalarMulTable, ScalarMul};
-    use manta_crypto::rand::OsRng;
+    use ark_ed_on_bls12_381::{constraints::EdwardsVar, EdwardsProjective};
+    use manta_crypto::{
+        constraint::ConstraintSystem,
+        ecc::{PreprocessedScalarMulTable, ScalarMul},
+        rand::OsRng,
+    };
     fn preprocessed_scalar_mul_test_template<C, CV, const N: usize>(rng: &mut OsRng)
     where
         C: ProjectiveCurve,

--- a/manta-pay/src/crypto/ecc/arkworks.rs
+++ b/manta-pay/src/crypto/ecc/arkworks.rs
@@ -406,6 +406,31 @@ where
     }
 }
 
+impl<C, CV, const N: usize> ecc::PreprocessedScalarMul<Compiler<C>, N> for GroupVar<C, CV> where
+    C: ProjectiveCurve,
+    CV: CurveVar<C, ConstraintField<C>> {
+    /// Performs the scalar multiplication against a pre-computed table.
+    ///
+    /// The pre-computed table is a list of power-of-two multiples of `scalar`, such that
+    /// `table[i] = scalar * 2^i`.
+    fn preprocessed_scalar_mul(table: &[Self; N], scalar: &Self::Scalar, compiler: &mut Compiler<C>) -> Self::Output {
+        // Computes the standard little-endian double-and-add algorithm
+        // (Algorithm 3.26, Guide to Elliptic Curve Cryptography)
+        // adapted from https://github.com/arkworks-rs/r1cs-std/blob/50ab8ee5ba8c09637044718eceac38e98e0ea67c/src/groups/mod.rs#L110-L139
+
+        let _ = compiler;
+        let mut result: CV = CV::zero();
+        let scalar_bits = scalar.0.to_bits_le().expect("Bit decomposition is not allowed to fail.");
+        debug_assert_eq!(scalar_bits.len(), N, "Scalar is expected to have N bits.");
+        for (bit, base) in scalar_bits.into_iter().zip(table.iter()){
+            // compute `self + 2^i * scalar`
+            let scalar_plus_base = result.clone() + base.0.clone();
+            result = bit.select(&scalar_plus_base, &result).expect("Conditional select is not allowed to fail. ");
+        }
+        Self(result, PhantomData)
+    }
+}
+
 impl<C, CV> Equal<Compiler<C>> for GroupVar<C, CV>
 where
     C: ProjectiveCurve,

--- a/manta-pay/src/crypto/ecc/arkworks.rs
+++ b/manta-pay/src/crypto/ecc/arkworks.rs
@@ -578,6 +578,7 @@ mod tests {
         ecc::{PreprocessedScalarMulTable, ScalarMul},
         rand::OsRng,
     };
+
     fn preprocessed_scalar_mul_test_template<C, CV, const N: usize>(rng: &mut OsRng)
     where
         C: ProjectiveCurve,
@@ -613,7 +614,19 @@ mod tests {
 
     #[test]
     fn preprocessed_scalar_mul_test() {
+        macro_rules! test_on_curve {
+            ($curve: ty, $var: ty, $rng: expr) => {
+                preprocessed_scalar_mul_test_template::<
+            $curve,
+            $var,
+            {
+                <<$curve as ProjectiveCurve>::ScalarField as PrimeField>::Params::MODULUS_BITS as usize
+            },
+        >($rng)
+            }
+        }
+
         let mut rng = OsRng::default();
-        preprocessed_scalar_mul_test_template::<EdwardsProjective, EdwardsVar, 252>(&mut rng);
+        test_on_curve!(EdwardsProjective, EdwardsVar, &mut rng);
     }
 }


### PR DESCRIPTION
Adds support for scalar multiplication using precomputed bases. 

Closes: #24 