### PR TITLE
Remove Trapdoor From Circuit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,10 @@ jobs:
       - uses: actions/checkout@v3
       - run: rustup update ${{ matrix.channel }} && rustup default ${{ matrix.channel }} && rustup component add clippy
       - run: cargo install cargo-hack
-      - run: cargo hack clippy --feature-powerset --bins --examples --tests --workspace
+      - run: cargo hack clippy --feature-powerset --workspace
+      - run: cargo hack clippy --feature-powerset --workspace --bins
+      - run: cargo hack clippy --feature-powerset --workspace --examples
+      - run: cargo hack clippy --feature-powerset --workspace --tests
   format:
     name: Format
     runs-on: ubuntu-latest

--- a/manta-accounting/src/transfer/mod.rs
+++ b/manta-accounting/src/transfer/mod.rs
@@ -42,6 +42,7 @@ use manta_crypto::{
     key::{KeyAgreementScheme, KeyDerivationFunction},
     rand::{CryptoRng, RngCore, Sample},
 };
+use manta_util::{Array, SizeLimit};
 
 #[cfg(feature = "serde")]
 use manta_util::serde::{Deserialize, Serialize};
@@ -138,7 +139,7 @@ pub trait VoidNumberCommitmentScheme<COM = ()> {
 /// Transfer Configuration
 pub trait Configuration {
     /// Secret Key Type
-    type SecretKey: Clone + Sample + WithSize;
+    type SecretKey: Clone + Sample + SizeLimit;
 
     /// Public Key Type
     type PublicKey: Clone;
@@ -1277,12 +1278,6 @@ where
     }
 }
 
-///
-pub trait WithSize {
-    ///
-    const SIZE: usize;
-}
-
 /// Note
 pub struct Note<C>
 where
@@ -1299,9 +1294,6 @@ impl<C> Note<C>
 where
     C: Configuration,
 {
-    /// Number of Bytes Required to Represent [`Note`]
-    pub const SIZE: usize = SecretKey::<C>::SIZE + Asset::SIZE;
-
     /// Builds a new plaintext [`Note`] from `ephemeral_secret_key` and `asset`.
     #[inline]
     pub fn new(ephemeral_secret_key: SecretKey<C>, asset: Asset) -> Self {
@@ -1310,6 +1302,13 @@ where
             asset,
         }
     }
+}
+
+impl<C> SizeLimit for Note<C>
+where
+    C: Configuration,
+{
+    const SIZE: usize = SecretKey::<C>::SIZE + Asset::SIZE;
 }
 
 /// Receiver

--- a/manta-accounting/src/transfer/mod.rs
+++ b/manta-accounting/src/transfer/mod.rs
@@ -203,7 +203,7 @@ pub trait Configuration {
     type VoidNumberVar: Variable<Public, Self::Compiler, Type = Self::VoidNumber>
         + Equal<Self::Compiler>;
 
-    /// Void Number Hash Function Variable Type
+    /// Void Number Commitment Scheme Variable Type
     type VoidNumberCommitmentSchemeVar: VoidNumberCommitmentScheme<
             Self::Compiler,
             SecretSpendKey = SecretKeyVar<Self>,

--- a/manta-accounting/src/transfer/test.rs
+++ b/manta-accounting/src/transfer/test.rs
@@ -85,8 +85,8 @@ pub struct ParametersDistribution<E = (), U = (), V = ()> {
     /// UTXO Commitment Scheme Distribution
     pub utxo_commitment: U,
 
-    /// Void Number Hash Function Distribution
-    pub void_number_hash: V,
+    /// Void Number Commitment Scheme Distribution
+    pub void_number_commitment_scheme: V,
 }
 
 impl<E, U, V, C> Sample<ParametersDistribution<E, U, V>> for Parameters<C>
@@ -104,7 +104,7 @@ where
         Parameters::new(
             rng.sample(distribution.note_encryption_scheme),
             rng.sample(distribution.utxo_commitment),
-            rng.sample(distribution.void_number_hash),
+            rng.sample(distribution.void_number_commitment_scheme),
         )
     }
 }

--- a/manta-accounting/src/transfer/test.rs
+++ b/manta-accounting/src/transfer/test.rs
@@ -29,7 +29,7 @@ use core::fmt::Debug;
 use manta_crypto::{
     accumulator::Accumulator,
     constraint::ProofSystem,
-    rand::{CryptoRng, Rand, RngCore, Sample, Standard},
+    rand::{CryptoRng, Rand, RngCore, Sample},
 };
 use manta_util::into_array_unchecked;
 
@@ -78,7 +78,7 @@ where
 /// Parameters Distribution
 #[derive(derivative::Derivative)]
 #[derivative(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
-pub struct ParametersDistribution<E = Standard, U = Standard, V = Standard> {
+pub struct ParametersDistribution<E = (), U = (), V = ()> {
     /// Note Encryption Scheme Distribution
     pub note_encryption_scheme: E,
 
@@ -294,9 +294,9 @@ where
             .map(|v| {
                 Receiver::new(
                     parameters,
+                    parameters.derive_owned(rng.gen()),
+                    parameters.derive_owned(rng.gen()),
                     rng.gen(),
-                    parameters.derive_owned(rng.gen()),
-                    parameters.derive_owned(rng.gen()),
                     asset_id.with(*v),
                 )
             })

--- a/manta-accounting/src/transfer/test.rs
+++ b/manta-accounting/src/transfer/test.rs
@@ -95,7 +95,7 @@ where
     C: Configuration,
     C::KeyAgreementScheme: Sample<K>,
     C::UtxoCommitmentScheme: Sample<U>,
-    C::VoidNumberHashFunction: Sample<V>,
+    C::VoidNumberCommitmentScheme: Sample<V>,
 {
     #[inline]
     fn sample<R>(distribution: ParametersDistribution<K, U, V>, rng: &mut R) -> Self

--- a/manta-accounting/src/wallet/ledger.rs
+++ b/manta-accounting/src/wallet/ledger.rs
@@ -50,6 +50,15 @@ where
     /// Sender Chunk Iterator Type
     type SenderChunk: IntoIterator<Item = VoidNumber<C>>;
 
+    /// Push Response Type
+    ///
+    /// This is the return type of the [`push`](Self::push) method. Use this type to customize the
+    /// ledger's response to posting a set of transactions, valid or otherwise. In most cases `bool`
+    /// or some result type like `Result<(), Error>` is sufficient. In other cases where the ledger
+    /// cannot respond immediately to the [`push`](Self::push) command, a subscription token can be
+    /// returned instead which can be used to listen to the result later on.
+    type PushResponse;
+
     /// Error Type
     type Error;
 
@@ -65,7 +74,7 @@ where
     fn push(
         &mut self,
         posts: Vec<TransferPost<C>>,
-    ) -> LocalBoxFutureResult<PushResponse, Self::Error>;
+    ) -> LocalBoxFutureResult<Self::PushResponse, Self::Error>;
 }
 
 /// Ledger Source Pull Response
@@ -127,22 +136,4 @@ where
 
     /// Ledger Sender Chunk
     pub senders: L::SenderChunk,
-}
-
-/// Ledger Source Push Response
-///
-/// This `struct` is created by the [`push`](Connection::push) method on [`Connection`].
-/// See its documentation for more.
-#[cfg_attr(
-    feature = "serde",
-    derive(Deserialize, Serialize),
-    serde(crate = "manta_util::serde", deny_unknown_fields)
-)]
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
-pub struct PushResponse {
-    /// Transaction Success Flag
-    ///
-    /// The `success` flag is set to `true` if the ledger accepted the vector of [`TransferPost`]
-    /// and the ledger has been updated to the new state.
-    pub success: bool,
 }

--- a/manta-accounting/src/wallet/mod.rs
+++ b/manta-accounting/src/wallet/mod.rs
@@ -36,7 +36,7 @@ use crate::{
     },
     wallet::{
         balance::{BTreeMapBalanceState, BalanceState},
-        ledger::{Checkpoint, PullResponse, PushResponse},
+        ledger::{Checkpoint, PullResponse},
         signer::{
             ReceivingKeyRequest, SignError, SignRequest, SignResponse, SyncError, SyncRequest,
             SyncResponse,
@@ -300,7 +300,7 @@ where
         &mut self,
         transaction: Transaction<C>,
         metadata: Option<AssetMetadata>,
-    ) -> Result<bool, Error<C, L, S>> {
+    ) -> Result<L::PushResponse, Error<C, L, S>> {
         self.sync().await?;
         self.check(&transaction)
             .map_err(Error::InsufficientBalance)?;
@@ -313,12 +313,10 @@ where
             .await
             .map_err(Error::SignerConnectionError)?
             .map_err(Error::SignError)?;
-        let PushResponse { success } = self
-            .ledger
+        self.ledger
             .push(posts)
             .await
-            .map_err(Error::LedgerConnectionError)?;
-        Ok(success)
+            .map_err(Error::LedgerConnectionError)
     }
 
     /// Returns public receiving keys according to the `request`.

--- a/manta-accounting/src/wallet/signer.rs
+++ b/manta-accounting/src/wallet/signer.rs
@@ -546,7 +546,7 @@ where
                 asset,
             } = item.plaintext;
             if let Some(void_number) =
-                parameters.check_full_asset(&ephemeral_secret_key, &keypair.spend, &asset, &utxo)
+                parameters.check_full_asset(&keypair.spend, &ephemeral_secret_key, &asset, &utxo)
             {
                 if let Some(index) = void_numbers.iter().position(move |v| v == &void_number) {
                     void_numbers.remove(index);

--- a/manta-accounting/src/wallet/signer.rs
+++ b/manta-accounting/src/wallet/signer.rs
@@ -569,8 +569,8 @@ where
     #[inline]
     fn is_asset_unspent(
         parameters: &Parameters<C>,
-        ephemeral_secret_key: &SecretKey<C>,
         secret_spend_key: &SecretKey<C>,
+        ephemeral_secret_key: &SecretKey<C>,
         asset: Asset,
         void_numbers: &mut Vec<VoidNumber<C>>,
         utxo_accumulator: &mut C::UtxoAccumulator,
@@ -624,8 +624,8 @@ where
                 |asset| match self.accounts.get_default().spend_key(*index) {
                     Some(secret_spend_key) => Self::is_asset_unspent(
                         parameters,
-                        ephemeral_secret_key,
                         &secret_spend_key,
+                        ephemeral_secret_key,
                         *asset,
                         &mut void_numbers,
                         &mut self.utxo_accumulator,

--- a/manta-accounting/src/wallet/signer.rs
+++ b/manta-accounting/src/wallet/signer.rs
@@ -36,9 +36,9 @@ use crate::{
             Mint, MultiProvingContext, PrivateTransfer, PrivateTransferShape, Reclaim, Selection,
             Shape, Transaction,
         },
-        EncryptedNote, FullParameters, Parameters, PreSender, ProofSystemError, ProvingContext,
-        PublicKey, Receiver, ReceivingKey, SecretKey, Sender, SpendingKey, Transfer, TransferPost,
-        Utxo, VoidNumber,
+        EncryptedNote, FullParameters, Note, Parameters, PreSender, ProofSystemError,
+        ProvingContext, Receiver, ReceivingKey, SecretKey, Sender, SpendingKey, Transfer,
+        TransferPost, Utxo, VoidNumber,
     },
 };
 use alloc::{boxed::Box, vec, vec::Vec};
@@ -381,7 +381,7 @@ pub trait Configuration: transfer::Configuration {
 pub type AccountTable<C> = key::AccountTable<<C as Configuration>::HierarchicalKeyDerivationScheme>;
 
 /// Asset Map Key Type
-pub type AssetMapKey<C> = (KeyIndex, PublicKey<C>);
+pub type AssetMapKey<C> = (KeyIndex, SecretKey<C>);
 
 /// Proving Context Cache Error Type
 pub type ProvingContextCacheError<C> =
@@ -436,7 +436,7 @@ where
         &self,
         keypair: SecretKeyPair<C::HierarchicalKeyDerivationScheme>,
     ) -> ReceivingKey<C> {
-        SpendingKey::new(keypair.spend, keypair.view).derive(&self.parameters.key_agreement)
+        SpendingKey::new(keypair.spend, keypair.view).derive(self.parameters.key_agreement_scheme())
     }
 }
 
@@ -533,30 +533,26 @@ where
         if let Some(ViewKeySelection {
             index,
             keypair,
-            item:
-                DecryptedMessage {
-                    plaintext: asset,
-                    ephemeral_public_key,
-                },
+            item,
         }) = self
             .accounts
             .get_mut_default()
             .find_index_with_maybe_gap(with_recovery, |k| {
-                finder.decrypt(&parameters.key_agreement, k)
+                finder.decrypt(&parameters.note_encryption_scheme, k)
             })
         {
-            if let Some(void_number) = C::check_full_asset(
-                parameters,
-                &keypair.spend,
-                &ephemeral_public_key,
-                &asset,
-                &utxo,
-            ) {
+            let Note {
+                ephemeral_secret_key,
+                asset,
+            } = item.plaintext;
+            if let Some(void_number) =
+                parameters.check_full_asset(&ephemeral_secret_key, &keypair.spend, &asset, &utxo)
+            {
                 if let Some(index) = void_numbers.iter().position(move |v| v == &void_number) {
                     void_numbers.remove(index);
                 } else {
                     self.utxo_accumulator.insert(&utxo);
-                    self.assets.insert((index, ephemeral_public_key), asset);
+                    self.assets.insert((index, ephemeral_secret_key), asset);
                     if !asset.is_zero() {
                         deposit.push(asset);
                     }
@@ -573,21 +569,19 @@ where
     #[inline]
     fn is_asset_unspent(
         parameters: &Parameters<C>,
-        secret_key: &SecretKey<C>,
-        ephemeral_public_key: &PublicKey<C>,
+        ephemeral_secret_key: &SecretKey<C>,
+        secret_spend_key: &SecretKey<C>,
         asset: Asset,
         void_numbers: &mut Vec<VoidNumber<C>>,
         utxo_accumulator: &mut C::UtxoAccumulator,
         withdraw: &mut Vec<Asset>,
     ) -> bool {
-        let utxo = C::utxo(
-            &parameters.key_agreement,
-            &parameters.utxo_commitment,
-            secret_key,
-            ephemeral_public_key,
+        let utxo = parameters.utxo(
+            ephemeral_secret_key,
+            &parameters.derive(secret_spend_key),
             &asset,
         );
-        let void_number = C::void_number(&parameters.void_number_hash, &utxo, secret_key);
+        let void_number = parameters.void_number(secret_spend_key, &utxo);
         if let Some(index) = void_numbers.iter().position(move |v| v == &void_number) {
             void_numbers.remove(index);
             utxo_accumulator.remove_proof(&utxo);
@@ -625,13 +619,13 @@ where
                 &mut deposit,
             )?;
         }
-        self.assets.retain(|(index, ephemeral_public_key), assets| {
+        self.assets.retain(|(index, ephemeral_secret_key), assets| {
             assets.retain(
                 |asset| match self.accounts.get_default().spend_key(*index) {
-                    Some(secret_key) => Self::is_asset_unspent(
+                    Some(secret_spend_key) => Self::is_asset_unspent(
                         parameters,
-                        &secret_key,
-                        ephemeral_public_key,
+                        ephemeral_secret_key,
+                        &secret_spend_key,
                         *asset,
                         &mut void_numbers,
                         &mut self.utxo_accumulator,
@@ -661,14 +655,14 @@ where
         key: AssetMapKey<C>,
         asset: Asset,
     ) -> Result<PreSender<C>, SignError<C>> {
-        let (spend_index, ephemeral_key) = key;
+        let (spend_index, ephemeral_secret_key) = key;
         Ok(PreSender::new(
             parameters,
             self.accounts
                 .get_default()
                 .spend_key(spend_index)
                 .expect("Index is guaranteed to be within bounds."),
-            ephemeral_key,
+            ephemeral_secret_key,
             asset,
         ))
     }

--- a/manta-accounting/src/wallet/test/mod.rs
+++ b/manta-accounting/src/wallet/test/mod.rs
@@ -17,6 +17,7 @@
 //! Testing and Simulation Framework
 
 // TODO: Perform delays instead of just `Skip` which doesn't really spread actors out in time.
+// TODO: Generalize `PushResponse` so that we can test against more general wallet setups.
 
 use crate::{
     asset::{Asset, AssetList},
@@ -267,7 +268,7 @@ where
 
 /// Simulation Event
 #[derive(derivative::Derivative)]
-#[derivative(Debug(bound = "Error<C, L, S>: Debug"))]
+#[derivative(Debug(bound = "L::PushResponse: Debug, Error<C, L, S>: Debug"))]
 pub struct Event<C, L, S>
 where
     C: transfer::Configuration,
@@ -278,7 +279,7 @@ where
     pub action: ActionType,
 
     /// Action Result
-    pub result: Result<bool, Error<C, L, S>>,
+    pub result: Result<L::PushResponse, Error<C, L, S>>,
 }
 
 /// Public Key Database
@@ -324,7 +325,7 @@ where
 impl<C, L, S> sim::ActionSimulation for Simulation<C, L, S>
 where
     C: transfer::Configuration,
-    L: ledger::Connection<C> + PublicBalanceOracle,
+    L: ledger::Connection<C, PushResponse = bool> + PublicBalanceOracle,
     S: signer::Connection<C>,
     PublicKey<C>: Eq + Hash,
 {
@@ -480,7 +481,7 @@ impl Config {
     ) -> Result<bool, Error<C, L, S>>
     where
         C: transfer::Configuration,
-        L: ledger::Connection<C> + PublicBalanceOracle,
+        L: ledger::Connection<C, PushResponse = bool> + PublicBalanceOracle,
         S: signer::Connection<C>,
         R: CryptoRng + RngCore,
         GL: FnMut(usize) -> L,

--- a/manta-crypto/src/constraint.rs
+++ b/manta-crypto/src/constraint.rs
@@ -22,9 +22,9 @@
 // TODO:  Find ways to enforce public input structure, since it's very easy to extend the input
 //        vector by the wrong amount or in the wrong order.
 
-use core::{fmt::Debug, hash::Hash, marker::PhantomData};
+use crate::rand::{CryptoRng, RngCore};
+use core::{fmt::Debug, hash::Hash, marker::PhantomData, ops};
 use manta_util::{create_seal, seal};
-use rand_core::{CryptoRng, RngCore};
 
 create_seal! {}
 
@@ -321,7 +321,7 @@ impl ConstraintSystem for () {
 
     #[inline]
     fn assert(&mut self, b: Self::Bool) {
-        assert!(b, "Native Constraint System assertion.");
+        assert!(b, "Native Constraint System Assertion");
     }
 }
 */
@@ -366,6 +366,18 @@ where
     }
 }
 
+/* TODO: Implement this:
+impl<T> Equal<()> for T
+where
+    T: PartialEq,
+{
+    #[inline]
+    fn eq(lhs: &Self, rhs: &Self, _: &mut ()) -> bool {
+        lhs.eq(rhs)
+    }
+}
+*/
+
 /// Conditional Selection
 pub trait ConditionalSelect<COM>
 where
@@ -398,6 +410,22 @@ where
     }
 }
 
+/* TODO: Implement this:
+impl<T> ConditionalSelect<()> for T
+where
+    T: Clone,
+{
+    #[inline]
+    fn select(bit: &bool, true_value: &Self, false_value: &Self, _: &mut ()) -> Self {
+        if bit {
+            true_value
+        } else {
+            false_value
+        }
+    }
+}
+*/
+
 /// Addition
 pub trait Add<COM>
 where
@@ -407,6 +435,16 @@ where
     fn add(lhs: Self, rhs: Self, compiler: &mut COM) -> Self;
 }
 
+impl<T> Add<()> for T
+where
+    T: ops::Add<Output = T>,
+{
+    #[inline]
+    fn add(lhs: Self, rhs: Self, _: &mut ()) -> Self {
+        lhs.add(rhs)
+    }
+}
+
 /// Subtraction
 pub trait Sub<COM>
 where
@@ -414,6 +452,16 @@ where
 {
     /// Subtracts `rhs` from `lhs` inside of `compiler`.
     fn sub(lhs: Self, rhs: Self, compiler: &mut COM) -> Self;
+}
+
+impl<T> Sub<()> for T
+where
+    T: ops::Sub<Output = T>,
+{
+    #[inline]
+    fn sub(lhs: Self, rhs: Self, _: &mut ()) -> Self {
+        lhs.sub(rhs)
+    }
 }
 
 /// Proof System

--- a/manta-crypto/src/ecc.rs
+++ b/manta-crypto/src/ecc.rs
@@ -20,7 +20,7 @@
 
 use crate::{
     constraint::Constant,
-    key::KeyAgreementScheme,
+    key::{KeyAgreementScheme, KeyDerivationFunction},
     rand::{CryptoRng, RngCore, Sample},
 };
 use alloc::{boxed::Box, vec::Vec};
@@ -321,6 +321,19 @@ where
     }
 }
 
+impl<G, COM> KeyDerivationFunction<COM> for DiffieHellman<G>
+where
+    G: ScalarMul<COM>,
+{
+    type Key = G::Scalar;
+    type Output = G::Output;
+
+    #[inline]
+    fn derive_in(&self, key: &Self::Key, compiler: &mut COM) -> Self::Output {
+        self.generator.scalar_mul(key, compiler)
+    }
+}
+
 impl<G, COM> KeyAgreementScheme<COM> for DiffieHellman<G>
 where
     G: ScalarMul<COM>,
@@ -329,11 +342,6 @@ where
     type SecretKey = G::Scalar;
     type PublicKey = G::Output;
     type SharedSecret = G::Output;
-
-    #[inline]
-    fn derive_in(&self, secret_key: &Self::SecretKey, compiler: &mut COM) -> Self::PublicKey {
-        self.generator.scalar_mul(secret_key, compiler)
-    }
 
     #[inline]
     fn agree_in(

--- a/manta-crypto/src/encryption/symmetric.rs
+++ b/manta-crypto/src/encryption/symmetric.rs
@@ -103,12 +103,12 @@ pub trait PlaintextMapping<P>: Sized {
     /// Plaintext Type
     type Plaintext;
 
-    /// Converts `self` into the plaintext space `P`.
-    fn into(plaintext: Self::Plaintext) -> P;
+    /// Converts `self` into the base plaintext space `P`.
+    fn into_base(plaintext: Self::Plaintext) -> P;
 
-    /// Converts from `plaintext` to [`Plaintext`](Self::Plaintext) returning `None` if the
+    /// Converts from the base `plaintext` to [`Plaintext`](Self::Plaintext) returning `None` if the
     /// conversion failed.
-    fn from(plaintext: P) -> Option<Self::Plaintext>;
+    fn from_base(plaintext: P) -> Option<Self::Plaintext>;
 }
 
 /// [`TryFrom`] Plaintext Mapping
@@ -130,12 +130,12 @@ where
     type Plaintext = Q;
 
     #[inline]
-    fn into(plaintext: Self::Plaintext) -> P {
+    fn into_base(plaintext: Self::Plaintext) -> P {
         plaintext.into()
     }
 
     #[inline]
-    fn from(plaintext: P) -> Option<Self::Plaintext> {
+    fn from_base(plaintext: P) -> Option<Self::Plaintext> {
         plaintext.try_into().ok()
     }
 }
@@ -236,12 +236,12 @@ where
 
     #[inline]
     fn encrypt(&self, key: Self::Key, plaintext: Self::Plaintext) -> Self::Ciphertext {
-        self.cipher.encrypt(key, F::into(plaintext))
+        self.cipher.encrypt(key, F::into_base(plaintext))
     }
 
     #[inline]
     fn decrypt(&self, key: Self::Key, ciphertext: &Self::Ciphertext) -> Option<Self::Plaintext> {
-        self.cipher.decrypt(key, ciphertext).and_then(F::from)
+        self.cipher.decrypt(key, ciphertext).and_then(F::from_base)
     }
 }
 

--- a/manta-crypto/src/hash.rs
+++ b/manta-crypto/src/hash.rs
@@ -51,7 +51,6 @@ where
         (*self).hash_in(input, compiler)
     }
 
-    /// Computes the hash over `input`.
     #[inline]
     fn hash(&self, input: &Self::Input) -> Self::Output
     where

--- a/manta-crypto/src/merkle_tree/tree.rs
+++ b/manta-crypto/src/merkle_tree/tree.rs
@@ -703,14 +703,10 @@ where
         R: Read,
     {
         Ok(Self::new(
-            LeafHashParameters::<C, COM>::decode(&mut reader).map_err(|err| match err {
-                DecodeError::Decode(err) => DecodeError::Decode(ParameterDecodeError::Leaf(err)),
-                DecodeError::Read(err) => DecodeError::Read(err),
-            })?,
-            InnerHashParameters::<C, COM>::decode(&mut reader).map_err(|err| match err {
-                DecodeError::Decode(err) => DecodeError::Decode(ParameterDecodeError::Inner(err)),
-                DecodeError::Read(err) => DecodeError::Read(err),
-            })?,
+            LeafHashParameters::<C, COM>::decode(&mut reader)
+                .map_err(|err| err.map_decode(ParameterDecodeError::Leaf))?,
+            InnerHashParameters::<C, COM>::decode(&mut reader)
+                .map_err(|err| err.map_decode(ParameterDecodeError::Inner))?,
         ))
     }
 }

--- a/manta-crypto/src/rand.rs
+++ b/manta-crypto/src/rand.rs
@@ -401,6 +401,14 @@ pub trait Rand: CryptoRng + RngCore {
         T::try_gen(self)
     }
 
+    /// Fills a buffer of `N` bytes randomly.
+    #[inline]
+    fn gen_bytes<const N: usize>(&mut self) -> [u8; N] {
+        let mut bytes = [0; N];
+        self.fill_bytes(&mut bytes);
+        bytes
+    }
+
     /// Seeds another random number generator `R` using entropy from `self`.
     #[inline]
     fn seed_rng<R>(&mut self) -> Result<R, Error>

--- a/manta-crypto/src/rand.rs
+++ b/manta-crypto/src/rand.rs
@@ -192,12 +192,8 @@ where
     }
 }
 
-/// Standard Distribution
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct Standard;
-
 /// Sampling Trait
-pub trait Sample<D = Standard>: Sized {
+pub trait Sample<D = ()>: Sized {
     /// Returns a random value of type `Self`, sampled according to the given `distribution`,
     /// generated from the `rng`.
     fn sample<R>(distribution: D, rng: &mut R) -> Self
@@ -222,7 +218,7 @@ macro_rules! impl_sample_from_u32 {
         $(
             impl Sample for $type {
                 #[inline]
-                fn sample<R>(distribution: Standard, rng: &mut R) -> Self
+                fn sample<R>(distribution: (), rng: &mut R) -> Self
                 where
                     R: RngCore + ?Sized,
                 {
@@ -238,7 +234,7 @@ impl_sample_from_u32!(i8, i16, i32, u8, u16, u32);
 
 impl Sample for u64 {
     #[inline]
-    fn sample<R>(distribution: Standard, rng: &mut R) -> Self
+    fn sample<R>(distribution: (), rng: &mut R) -> Self
     where
         R: CryptoRng + RngCore + ?Sized,
     {
@@ -249,7 +245,7 @@ impl Sample for u64 {
 
 impl Sample for u128 {
     #[inline]
-    fn sample<R>(distribution: Standard, rng: &mut R) -> Self
+    fn sample<R>(distribution: (), rng: &mut R) -> Self
     where
         R: CryptoRng + RngCore + ?Sized,
     {
@@ -329,7 +325,7 @@ where
 }
 
 /// Fallible Sampling Trait
-pub trait TrySample<D = Standard>: Sized {
+pub trait TrySample<D = ()>: Sized {
     /// Error Type
     type Error;
 

--- a/manta-pay/Cargo.toml
+++ b/manta-pay/Cargo.toml
@@ -30,7 +30,7 @@ required-features = ["groth16", "manta-util/std", "test"]
 
 [[bin]]
 name = "measure"
-required-features = ["groth16"]
+required-features = ["groth16", "manta-crypto/getrandom"]
 
 [[bin]]
 name = "simulation"

--- a/manta-pay/Cargo.toml
+++ b/manta-pay/Cargo.toml
@@ -30,7 +30,7 @@ required-features = ["groth16", "manta-util/std", "test"]
 
 [[bin]]
 name = "measure"
-required-features = ["groth16", "manta-crypto/getrandom"]
+required-features = ["groth16", "manta-crypto/getrandom", "test"]
 
 [[bin]]
 name = "simulation"

--- a/manta-pay/src/bin/generate_parameters.rs
+++ b/manta-pay/src/bin/generate_parameters.rs
@@ -70,23 +70,22 @@ pub fn main() -> io::Result<()> {
     let utxo_accumulator_model: UtxoAccumulatorModel = rng.gen();
 
     let Parameters {
-        key_agreement,
+        note_encryption_scheme,
         utxo_commitment,
-        void_number_hash,
+        void_number_commitment,
     } = &parameters;
 
     let parameters_dir = target_dir.join("parameters");
     fs::create_dir_all(&parameters_dir)?;
 
-    key_agreement
+    note_encryption_scheme
         .encode(IoWriter(
             OpenOptions::new()
                 .create(true)
                 .write(true)
-                .open(parameters_dir.join("key-agreement.dat"))?,
+                .open(parameters_dir.join("note-encryption-scheme.dat"))?,
         ))
         .unwrap();
-
     utxo_commitment
         .encode(IoWriter(
             OpenOptions::new()
@@ -95,16 +94,11 @@ pub fn main() -> io::Result<()> {
                 .open(parameters_dir.join("utxo-commitment-scheme.dat"))?,
         ))
         .unwrap();
-
-    void_number_hash
-        .encode(IoWriter(
-            OpenOptions::new()
-                .create(true)
-                .write(true)
-                .open(parameters_dir.join("void-number-hash-function.dat"))?,
-        ))
+    void_number_commitment
+        .encode(IoWriter(OpenOptions::new().create(true).write(true).open(
+            parameters_dir.join("void-number-commitment-scheme.dat"),
+        )?))
         .unwrap();
-
     utxo_accumulator_model
         .encode(IoWriter(
             OpenOptions::new()

--- a/manta-pay/src/bin/generate_parameters.rs
+++ b/manta-pay/src/bin/generate_parameters.rs
@@ -125,7 +125,7 @@ pub fn main() -> io::Result<()> {
             OpenOptions::new()
                 .create(true)
                 .write(true)
-                .open(proving_context_dir.join("mint.dat"))?,
+                .open(proving_context_dir.join("mint.lfs"))?,
         ))
         .unwrap();
     verifying_context
@@ -146,7 +146,7 @@ pub fn main() -> io::Result<()> {
             OpenOptions::new()
                 .create(true)
                 .write(true)
-                .open(proving_context_dir.join("private-transfer.dat"))?,
+                .open(proving_context_dir.join("private-transfer.lfs"))?,
         ))
         .unwrap();
     verifying_context
@@ -167,7 +167,7 @@ pub fn main() -> io::Result<()> {
             OpenOptions::new()
                 .create(true)
                 .write(true)
-                .open(proving_context_dir.join("reclaim.dat"))?,
+                .open(proving_context_dir.join("reclaim.lfs"))?,
         ))
         .unwrap();
     verifying_context

--- a/manta-pay/src/bin/measure.rs
+++ b/manta-pay/src/bin/measure.rs
@@ -18,8 +18,8 @@
 
 use manta_crypto::{
     constraint::{measure::Instrument, Allocator, Secret, ValueSource},
-    hash::HashFunction,
-    key::KeyAgreementScheme as _,
+    hash::ArrayHashFunction,
+    key::{KeyAgreementScheme as _, KeyDerivationFunction},
     rand::{Sample, SeedableRng},
 };
 use manta_pay::config::{

--- a/manta-pay/src/bin/measure.rs
+++ b/manta-pay/src/bin/measure.rs
@@ -20,7 +20,7 @@ use manta_crypto::{
     constraint::{measure::Instrument, Allocator, Secret, ValueSource},
     hash::ArrayHashFunction,
     key::{KeyAgreementScheme as _, KeyDerivationFunction},
-    rand::{Sample, SeedableRng},
+    rand::{FromEntropy, Sample, SeedableRng},
 };
 use manta_pay::config::{
     Compiler, KeyAgreementScheme, KeyAgreementSchemeVar, Poseidon2, Poseidon2Var, Poseidon4,

--- a/manta-pay/src/bin/measure.rs
+++ b/manta-pay/src/bin/measure.rs
@@ -20,7 +20,7 @@ use manta_crypto::{
     constraint::{measure::Instrument, Allocator, Secret, ValueSource},
     hash::ArrayHashFunction,
     key::{KeyAgreementScheme as _, KeyDerivationFunction},
-    rand::{FromEntropy, Sample, SeedableRng},
+    rand::{Sample, SeedableRng},
 };
 use manta_pay::config::{
     Compiler, KeyAgreementScheme, KeyAgreementSchemeVar, Poseidon2, Poseidon2Var, Poseidon4,

--- a/manta-pay/src/config.rs
+++ b/manta-pay/src/config.rs
@@ -628,7 +628,7 @@ impl encryption::symmetric::PlaintextMapping<Array<u8, { Note::SIZE }>> for Note
     type Plaintext = Note;
 
     #[inline]
-    fn into(plaintext: Self::Plaintext) -> Array<u8, { Note::SIZE }> {
+    fn into_base(plaintext: Self::Plaintext) -> Array<u8, { Note::SIZE }> {
         // TODO: Use a serialization method to do this.
         let mut bytes = Vec::new();
         bytes.append(&mut field_element_as_bytes(
@@ -641,7 +641,7 @@ impl encryption::symmetric::PlaintextMapping<Array<u8, { Note::SIZE }>> for Note
     }
 
     #[inline]
-    fn from(plaintext: Array<u8, { Note::SIZE }>) -> Option<Self::Plaintext> {
+    fn from_base(plaintext: Array<u8, { Note::SIZE }>) -> Option<Self::Plaintext> {
         // TODO: Use a deserialization method to do this.
         let mut slice = plaintext.as_ref();
         Some(Note {

--- a/manta-pay/src/config.rs
+++ b/manta-pay/src/config.rs
@@ -67,7 +67,7 @@ pub(crate) use bls12_381_ed::EdwardsProjective as Bls12_381_Edwards;
 /// Pairing Curve Type
 pub type PairingCurve = Bls12_381;
 
-/// Embedded Scalar Type
+/// Embedded Scalar Field Type
 pub type EmbeddedScalarField = bls12_381_ed::Fr;
 
 /// Embedded Scalar Type

--- a/manta-pay/src/config.rs
+++ b/manta-pay/src/config.rs
@@ -46,7 +46,10 @@ use manta_crypto::{
     hash::ArrayHashFunction,
     key, merkle_tree,
 };
-use manta_util::codec::{Decode, DecodeError, Encode, Read, Write};
+use manta_util::{
+    codec::{Decode, DecodeError, Encode, Read, Write},
+    SizeLimit,
+};
 
 #[cfg(feature = "bs58")]
 use alloc::string::String;
@@ -622,8 +625,8 @@ pub type NoteEncryptionScheme = encryption::hybrid::Hybrid<
         Blake2sKdf,
     >,
     encryption::symmetric::Map<
-        FixedNonceAesGcm<{ Asset::SIZE }, { aes::ciphertext_size(Asset::SIZE) }>,
-        Asset,
+        FixedNonceAesGcm<{ Note::SIZE }, { aes::ciphertext_size(Note::SIZE) }>,
+        Note,
     >,
 >;
 
@@ -674,6 +677,9 @@ pub type Parameters = transfer::Parameters<Config>;
 
 /// Full Transfer Parameters
 pub type FullParameters<'p> = transfer::FullParameters<'p, Config>;
+
+/// Note Type
+pub type Note = transfer::Note<Config>;
 
 /// Encrypted Note Type
 pub type EncryptedNote = transfer::EncryptedNote<Config>;

--- a/manta-pay/src/config.rs
+++ b/manta-pay/src/config.rs
@@ -621,6 +621,7 @@ impl ProofSystemInput<Group> for ProofSystem {
 }
 
 /// Note Plaintext Mapping
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct NotePlaintextMapping;
 
 impl encryption::symmetric::PlaintextMapping<Array<u8, { Note::SIZE }>> for NotePlaintextMapping {

--- a/manta-pay/src/crypto/constraint/arkworks/mod.rs
+++ b/manta-pay/src/crypto/constraint/arkworks/mod.rs
@@ -28,7 +28,7 @@ use manta_crypto::{
         measure::Measure, Add, ConditionalSelect, Constant, ConstraintSystem, Equal, Public,
         Secret, Variable,
     },
-    rand::{CryptoRng, RngCore, Sample, Standard},
+    rand::{CryptoRng, RngCore, Sample},
 };
 use manta_util::{
     codec::{Decode, DecodeError, Encode, Read, Write},
@@ -86,7 +86,7 @@ where
         R: Read,
     {
         let mut reader = codec::ArkReader::new(reader);
-        match codec::CanonicalDeserialize::deserialize(&mut reader) {
+        match F::deserialize(&mut reader) {
             Ok(value) => reader
                 .finish()
                 .map(move |_| Self(value))
@@ -123,8 +123,7 @@ where
         I: scale_codec::Input,
     {
         Ok(Self(
-            codec::CanonicalDeserialize::deserialize(codec::ScaleCodecReader(input))
-                .map_err(|_| "Deserialization Error")?,
+            F::deserialize(codec::ScaleCodecReader(input)).map_err(|_| "Deserialization Error")?,
         ))
     }
 }
@@ -182,7 +181,7 @@ where
     F: Field,
 {
     #[inline]
-    fn sample<R>(distribution: Standard, rng: &mut R) -> Self
+    fn sample<R>(distribution: (), rng: &mut R) -> Self
     where
         R: CryptoRng + RngCore + ?Sized,
     {

--- a/manta-pay/src/crypto/constraint/arkworks/mod.rs
+++ b/manta-pay/src/crypto/constraint/arkworks/mod.rs
@@ -17,7 +17,7 @@
 //! Arkworks Constraint System and Proof System Implementations
 
 use alloc::vec::Vec;
-use ark_ff::{Field, PrimeField};
+use ark_ff::{Field, FpParameters, PrimeField};
 use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, select::CondSelectGadget};
 use ark_relations::{
     ns, r1cs as ark_r1cs,
@@ -31,12 +31,10 @@ use manta_crypto::{
     rand::{CryptoRng, RngCore, Sample},
 };
 use manta_util::{
+    byte_count,
     codec::{Decode, DecodeError, Encode, Read, Write},
     SizeLimit,
 };
-
-#[cfg(feature = "scale")]
-use {ark_ff::FpParameters, manta_util::byte_count};
 
 #[cfg(feature = "serde")]
 use manta_util::serde::{Deserialize, Serialize, Serializer};

--- a/manta-pay/src/crypto/constraint/arkworks/mod.rs
+++ b/manta-pay/src/crypto/constraint/arkworks/mod.rs
@@ -30,7 +30,10 @@ use manta_crypto::{
     },
     rand::{CryptoRng, RngCore, Sample, Standard},
 };
-use manta_util::codec::{Decode, DecodeError, Encode, Read, Write};
+use manta_util::{
+    codec::{Decode, DecodeError, Encode, Read, Write},
+    SizeLimit,
+};
 
 #[cfg(feature = "scale")]
 use {ark_ff::FpParameters, manta_util::byte_count};
@@ -186,6 +189,13 @@ where
         let _ = distribution;
         Self(F::rand(rng))
     }
+}
+
+impl<F> SizeLimit for Fp<F>
+where
+    F: PrimeField,
+{
+    const SIZE: usize = byte_count(<F::Params as FpParameters>::MODULUS_BITS) as usize;
 }
 
 impl<F> TryFrom<Vec<u8>> for Fp<F>

--- a/manta-pay/src/crypto/ecc/arkworks.rs
+++ b/manta-pay/src/crypto/ecc/arkworks.rs
@@ -27,7 +27,7 @@ use manta_crypto::{
     constraint::{Allocator, Constant, Equal, Public, Secret, ValueSource, Variable},
     ecc::{self, PointAdd, PointDouble},
     key::kdf,
-    rand::{CryptoRng, RngCore, Sample, Standard},
+    rand::{CryptoRng, RngCore, Sample},
 };
 use manta_util::codec;
 
@@ -250,7 +250,7 @@ where
     C: ProjectiveCurve,
 {
     #[inline]
-    fn sample<R>(distribution: Standard, rng: &mut R) -> Self
+    fn sample<R>(distribution: (), rng: &mut R) -> Self
     where
         R: CryptoRng + RngCore + ?Sized,
     {

--- a/manta-pay/src/crypto/encryption.rs
+++ b/manta-pay/src/crypto/encryption.rs
@@ -130,18 +130,16 @@ mod test {
     use crate::config::NoteSymmetricEncryptionScheme;
     use manta_crypto::{
         encryption,
-        rand::{OsRng, Rand, RngCore},
+        rand::{OsRng, Rand},
     };
 
     /// Tests if symmetric encryption of [`Note`] decrypts properly.
     #[test]
     fn note_encryption() {
         let mut rng = OsRng;
-        let mut key = [0; 32];
-        rng.fill_bytes(&mut key);
         encryption::symmetric::test::encryption::<NoteSymmetricEncryptionScheme>(
-            &Default::default(),
-            key,
+            &rng.gen(),
+            rng.gen_bytes(),
             rng.gen(),
         );
     }

--- a/manta-pay/src/crypto/encryption.rs
+++ b/manta-pay/src/crypto/encryption.rs
@@ -127,7 +127,7 @@ pub mod aes {
 /// Test Suite
 #[cfg(test)]
 mod test {
-    use crate::config::NoteSymmetricEncryptionScheme;
+    use crate::config::{NoteEncryptionScheme, NoteSymmetricEncryptionScheme};
     use manta_crypto::{
         encryption,
         rand::{OsRng, Rand},
@@ -135,11 +135,23 @@ mod test {
 
     /// Tests if symmetric encryption of [`Note`] decrypts properly.
     #[test]
-    fn note_encryption() {
+    fn note_symmetric_encryption() {
         let mut rng = OsRng;
         encryption::symmetric::test::encryption::<NoteSymmetricEncryptionScheme>(
             &rng.gen(),
             rng.gen_bytes(),
+            rng.gen(),
+        );
+    }
+
+    /// Tests if the hybrid encryption of [`Note`] decrypts properly.
+    #[test]
+    fn note_hybrid_encryption() {
+        let mut rng = OsRng;
+        encryption::hybrid::test::encryption::<NoteEncryptionScheme>(
+            &rng.gen(),
+            &rng.gen(),
+            &rng.gen(),
             rng.gen(),
         );
     }

--- a/manta-pay/src/crypto/encryption.rs
+++ b/manta-pay/src/crypto/encryption.rs
@@ -90,18 +90,39 @@ pub mod aes {
             encryption,
             rand::{OsRng, RngCore},
         };
+        use manta_util::Array;
+
+        /// Tests the encryption of a mapped
+        #[inline]
+        fn encryption<T>()
+        where
+            T: SizeLimit + Into<Array<u8, T::SIZE>> + TryFrom<Array<u8, T::SIZE>>,
+        {
+            let mut rng = OsRng;
+            let mut key = [0; 32];
+            rng.fill_bytes(&mut key);
+            let mut plaintext = [0; T::SIZE];
+            rng.fill_bytes(&mut plaintext);
+            encryption::symmetric::test::encryption::<
+                encryption::symmetric::Map<
+                    FixedNonceAesGcm<{ T::SIZE }, { ciphertext_size(T::SIZE) }>,
+                    T,
+                >,
+            >(key, Array(plaintext));
+        }
 
         /// Tests if symmetric encryption of [`Asset`] decrypts properly.
         #[test]
         fn asset_encryption() {
-            let mut rng = OsRng;
-            let mut key = [0; 32];
-            rng.fill_bytes(&mut key);
-            let mut plaintext = [0; Asset::SIZE];
-            rng.fill_bytes(&mut plaintext);
-            encryption::symmetric::test::encryption::<
-                FixedNonceAesGcm<{ Asset::SIZE }, { ciphertext_size(Asset::SIZE) }>,
-            >(key, Array(plaintext));
+            test::encryption::<Asset>();
         }
+
+        /* TODO:
+        /// Tests if symmetric encryption of [`Note`] decrypts properly.
+        #[test]
+        fn note_encryption() {
+            test::encryption::<Note>();
+        }
+        */
     }
 }

--- a/manta-pay/src/crypto/encryption.rs
+++ b/manta-pay/src/crypto/encryption.rs
@@ -58,7 +58,7 @@ pub mod aes {
         type Ciphertext = Array<u8, C>;
 
         #[inline]
-        fn encrypt(key: Self::Key, plaintext: Self::Plaintext) -> Self::Ciphertext {
+        fn encrypt(&self, key: Self::Key, plaintext: Self::Plaintext) -> Self::Ciphertext {
             Array::from_unchecked(
                 Aes256Gcm::new_from_slice(&key)
                     .expect("The key has the correct size.")
@@ -68,7 +68,11 @@ pub mod aes {
         }
 
         #[inline]
-        fn decrypt(key: Self::Key, ciphertext: &Self::Ciphertext) -> Option<Self::Plaintext> {
+        fn decrypt(
+            &self,
+            key: Self::Key,
+            ciphertext: &Self::Ciphertext,
+        ) -> Option<Self::Plaintext> {
             Aes256Gcm::new_from_slice(&key)
                 .expect("The key has the correct size.")
                 .decrypt(Nonce::from_slice(Self::NONCE), ciphertext.as_ref())

--- a/manta-pay/src/crypto/key.rs
+++ b/manta-pay/src/crypto/key.rs
@@ -29,9 +29,9 @@ impl KeyDerivationFunction for Blake2sKdf {
     type Output = [u8; 32];
 
     #[inline]
-    fn derive(secret: &Self::Key) -> Self::Output {
+    fn derive_in(&self, key: &Self::Key, _: &mut ()) -> Self::Output {
         let mut hasher = Blake2s::new();
-        hasher.update(secret);
+        hasher.update(key);
         hasher.update(b"manta kdf instantiated with blake2s hash function");
         into_array_unchecked(hasher.finalize())
     }

--- a/manta-pay/src/crypto/key.rs
+++ b/manta-pay/src/crypto/key.rs
@@ -17,8 +17,15 @@
 //! Cryptographic Key Primitive Implementations
 
 use blake2::{Blake2s, Digest};
-use manta_crypto::key::KeyDerivationFunction;
-use manta_util::into_array_unchecked;
+use core::convert::Infallible;
+use manta_crypto::{
+    key::KeyDerivationFunction,
+    rand::{CryptoRng, RngCore, Sample},
+};
+use manta_util::{
+    codec::{Decode, DecodeError, Encode, Read, Write},
+    into_array_unchecked,
+};
 
 /// Blake2s KDF
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -34,5 +41,40 @@ impl KeyDerivationFunction for Blake2sKdf {
         hasher.update(key);
         hasher.update(b"manta kdf instantiated with blake2s hash function");
         into_array_unchecked(hasher.finalize())
+    }
+}
+
+impl Decode for Blake2sKdf {
+    type Error = Infallible;
+
+    #[inline]
+    fn decode<R>(reader: R) -> Result<Self, DecodeError<R::Error, Self::Error>>
+    where
+        R: Read,
+    {
+        let _ = reader;
+        Ok(Self)
+    }
+}
+
+impl Encode for Blake2sKdf {
+    #[inline]
+    fn encode<W>(&self, writer: W) -> Result<(), W::Error>
+    where
+        W: Write,
+    {
+        let _ = writer;
+        Ok(())
+    }
+}
+
+impl Sample for Blake2sKdf {
+    #[inline]
+    fn sample<R>(distribution: (), rng: &mut R) -> Self
+    where
+        R: CryptoRng + RngCore + ?Sized,
+    {
+        let _ = (distribution, rng);
+        Self
     }
 }

--- a/manta-pay/src/crypto/key.rs
+++ b/manta-pay/src/crypto/key.rs
@@ -17,15 +17,11 @@
 //! Cryptographic Key Primitive Implementations
 
 use blake2::{Blake2s, Digest};
-use core::convert::Infallible;
 use manta_crypto::{
     key::KeyDerivationFunction,
     rand::{CryptoRng, RngCore, Sample},
 };
-use manta_util::{
-    codec::{Decode, DecodeError, Encode, Read, Write},
-    into_array_unchecked,
-};
+use manta_util::{impl_empty_codec, into_array_unchecked};
 
 /// Blake2s KDF
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -44,29 +40,7 @@ impl KeyDerivationFunction for Blake2sKdf {
     }
 }
 
-impl Decode for Blake2sKdf {
-    type Error = Infallible;
-
-    #[inline]
-    fn decode<R>(reader: R) -> Result<Self, DecodeError<R::Error, Self::Error>>
-    where
-        R: Read,
-    {
-        let _ = reader;
-        Ok(Self)
-    }
-}
-
-impl Encode for Blake2sKdf {
-    #[inline]
-    fn encode<W>(&self, writer: W) -> Result<(), W::Error>
-    where
-        W: Write,
-    {
-        let _ = writer;
-        Ok(())
-    }
-}
+impl_empty_codec! { Blake2sKdf }
 
 impl Sample for Blake2sKdf {
     #[inline]

--- a/manta-pay/src/key.rs
+++ b/manta-pay/src/key.rs
@@ -29,7 +29,7 @@ use core::marker::PhantomData;
 use manta_accounting::key::{
     self, AccountIndex, HierarchicalKeyDerivationScheme, IndexType, KeyIndex, Kind,
 };
-use manta_crypto::rand::{CryptoRng, RngCore, Sample, Standard};
+use manta_crypto::rand::{CryptoRng, RngCore, Sample};
 use manta_util::{create_seal, seal, Array};
 
 #[cfg(feature = "serde")]
@@ -181,7 +181,7 @@ where
     C: CoinType,
 {
     #[inline]
-    fn sample<R>(distribution: Standard, rng: &mut R) -> Self
+    fn sample<R>(distribution: (), rng: &mut R) -> Self
     where
         R: CryptoRng + RngCore + ?Sized,
     {
@@ -290,7 +290,7 @@ impl PartialEq for Mnemonic {
 
 impl Sample for Mnemonic {
     #[inline]
-    fn sample<R>(distribution: Standard, rng: &mut R) -> Self
+    fn sample<R>(distribution: (), rng: &mut R) -> Self
     where
         R: CryptoRng + RngCore + ?Sized,
     {

--- a/manta-pay/src/simulation/ledger/http/client.rs
+++ b/manta-pay/src/simulation/ledger/http/client.rs
@@ -24,7 +24,7 @@ use crate::{
 use manta_accounting::{
     asset::AssetList,
     wallet::{
-        ledger::{self, PullResponse, PushResponse},
+        ledger::{self, PullResponse},
         test::PublicBalanceOracle,
     },
 };
@@ -57,6 +57,7 @@ impl ledger::Connection<Config> for Client {
     type Checkpoint = Checkpoint;
     type ReceiverChunk = Vec<(Utxo, EncryptedNote)>;
     type SenderChunk = Vec<VoidNumber>;
+    type PushResponse = bool;
     type Error = Error;
 
     #[inline]
@@ -81,7 +82,7 @@ impl ledger::Connection<Config> for Client {
     fn push(
         &mut self,
         posts: Vec<TransferPost>,
-    ) -> LocalBoxFutureResult<PushResponse, Self::Error> {
+    ) -> LocalBoxFutureResult<Self::PushResponse, Self::Error> {
         Box::pin(async move {
             self.client
                 .post(

--- a/manta-pay/src/simulation/ledger/http/server.rs
+++ b/manta-pay/src/simulation/ledger/http/server.rs
@@ -24,10 +24,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 use core::future::Future;
-use manta_accounting::{
-    asset::AssetList,
-    wallet::ledger::{PullResponse, PushResponse},
-};
+use manta_accounting::{asset::AssetList, wallet::ledger::PullResponse};
 use manta_util::serde::{de::DeserializeOwned, Serialize};
 use tide::{listener::ToListener, Body, Response};
 use tokio::{io, sync::RwLock};
@@ -56,7 +53,7 @@ impl State {
 
     /// Pushes data to the ledger with the given `account` and `posts`.
     #[inline]
-    async fn push(self, account: AccountId, posts: Vec<TransferPost>) -> PushResponse {
+    async fn push(self, account: AccountId, posts: Vec<TransferPost>) -> bool {
         self.0.write().await.push(account, posts)
     }
 

--- a/manta-pay/src/simulation/mod.rs
+++ b/manta-pay/src/simulation/mod.rs
@@ -133,7 +133,7 @@ impl Simulation {
     #[inline]
     pub async fn run_with<L, S, GL, GS>(&self, ledger: GL, signer: GS)
     where
-        L: wallet::ledger::Connection<Config> + PublicBalanceOracle,
+        L: wallet::ledger::Connection<Config, PushResponse = bool> + PublicBalanceOracle,
         S: wallet::signer::Connection<Config>,
         GL: FnMut(usize) -> L,
         GS: FnMut(usize) -> S,

--- a/manta-util/src/array.rs
+++ b/manta-util/src/array.rs
@@ -28,18 +28,19 @@ use alloc::{boxed::Box, vec::Vec};
 #[cfg(feature = "serde-array")]
 use crate::serde::{Deserialize, Serialize};
 
+/// Error Message for the [`into_array_unchecked`] and [`into_boxed_array_unchecked`] messages.
+const INTO_UNCHECKED_ERROR_MESSAGE: &str =
+    "Input did not have the correct length to match the output array of length";
+
 /// Performs the [`TryInto`] conversion into an array without checking if the conversion succeeded.
 #[inline]
-pub fn into_array_unchecked<T, V, const N: usize>(v: V) -> [T; N]
+pub fn into_array_unchecked<T, V, const N: usize>(value: V) -> [T; N]
 where
     V: TryInto<[T; N]>,
 {
-    match v.try_into() {
+    match value.try_into() {
         Ok(array) => array,
-        _ => unreachable!(
-            "Input did not have the correct length to match the output slice of length {:?}.",
-            N,
-        ),
+        _ => unreachable!("{} {:?}.", INTO_UNCHECKED_ERROR_MESSAGE, N),
     }
 }
 
@@ -48,16 +49,13 @@ where
 #[cfg(feature = "alloc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 #[inline]
-pub fn into_boxed_array_unchecked<T, V, const N: usize>(v: V) -> Box<[T; N]>
+pub fn into_boxed_array_unchecked<T, V, const N: usize>(value: V) -> Box<[T; N]>
 where
     V: TryInto<Box<[T; N]>>,
 {
-    match v.try_into() {
-        Ok(array) => array,
-        _ => unreachable!(
-            "Input did not have the correct length to match the output slice of length {:?}.",
-            N,
-        ),
+    match value.try_into() {
+        Ok(boxed_array) => boxed_array,
+        _ => unreachable!("{} {:?}.", INTO_UNCHECKED_ERROR_MESSAGE, N),
     }
 }
 

--- a/manta-util/src/bytes.rs
+++ b/manta-util/src/bytes.rs
@@ -16,6 +16,15 @@
 
 //! Utilities for Manipulating Bytes
 
+/// Size Limit
+pub trait SizeLimit {
+    /// Maximum Number of Bytes Required to Represent [`Self`]
+    ///
+    /// If this trait is implemented, then we know that [`Self`] can fit inside a byte array of the
+    /// following type: `[u8; Self::SIZE]`.
+    const SIZE: usize;
+}
+
 /// Exact From Bytes Conversion
 pub trait FromBytes<const SIZE: usize> {
     /// Converts an array of `bytes` into an element of type [`Self`].


### PR DESCRIPTION
## Changes

- Replace trapdoor with secret key check on the `Sender` side
    - Trapdoor was the shared secret between the prover and the sender but it allowed the prover to impersonate the sender in the circuit
    - Now that the trapdoor is gone, we remove a scalar multiplication _(**3944** constraints & **3821** variables)_ from each `Sender` and `Receiver`
- Remove unnecessary ephemeral public key check on the `Receiver` side
    - The ephemeral public key check was leftover from previous design choices made on the encrypted note.
    - **NB**: We don't check the encrypted note in-circuit on purpose since we don't care about enforcing in-band secret distribution, it does not change the security/privacy guarantees on honest users.
    - Now that this check is gone we remove a (constant-base) scalar multiplication _(**1902** constraints & **1779** variables)_ from each `Receiver`
- Generalize some cryptographic primitives and add more encoding/decode methods

## Circuit Sizes

This upgrade reduces the circuit sizes considerably:

| CIRCUIT | CONSTRAINTS | Δ | SECRET VARIABLES | Δ | PUBLIC VARIABLES | Δ |
|:---|:--:|:--:|:--:|:--:|:--:|:--:|
| `Mint` | 450 | -5857 | 448 | -5607 | 4 | -2 |
| `PrivateTransfer` | 18148 | -15840 | 17936 | -15340 | 7 | -4 |
| `Reclaim` | 17706 | -9983 | 17492 | -9733 | 8 | -2 |