### PR TITLE
Bump scale-codec and scale-info

### DIFF
--- a/manta-pay/Cargo.toml
+++ b/manta-pay/Cargo.toml
@@ -127,8 +127,8 @@ parking_lot = { version = "0.12.0", optional = true, default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
 rayon = { version = "1.5.1", optional = true, default-features = false }
 reqwest = { version = "0.11.9", optional = true, default-features = false, features = ["json"] }
-scale-codec = { package = "parity-scale-codec", version = "2.3.1", optional = true, default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "1.0.0", optional = true, default-features = false, features = ["derive"] }
+scale-codec = { package = "parity-scale-codec", version = "3.0.0", optional = true, default-features = false, features = ["derive", "max-encoded-len"] }
+scale-info = { version = "2.0.0", optional = true, default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.79", optional = true, default-features = false, features = ["alloc"] }
 tide = { version = "0.16.0", optional = true, default-features = false, features = ["h1-server"] }
 tokio = { version = "1.17.0", optional = true, default-features = false }


### PR DESCRIPTION
Signed-off-by: Dengjianping <djptux@gmail.com>

I'm trying to bump them in manta, but if `manta-rs` sticks to older version, manta cannot be compiled.
So I have to bump them.