### PR TITLE
feat: add recovery to simulation

### DIFF
--- a/manta-accounting/src/asset.rs
+++ b/manta-accounting/src/asset.rs
@@ -701,6 +701,18 @@ impl From<Vec<Asset>> for AssetList {
     }
 }
 
+impl FromIterator<(AssetId, AssetValue)> for AssetList {
+    #[inline]
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = (AssetId, AssetValue)>,
+    {
+        iter.into_iter()
+            .map(move |(id, value)| Asset::new(id, value))
+            .collect()
+    }
+}
+
 impl FromIterator<Asset> for AssetList {
     #[inline]
     fn from_iter<I>(iter: I) -> Self

--- a/manta-accounting/src/wallet/mod.rs
+++ b/manta-accounting/src/wallet/mod.rs
@@ -29,7 +29,7 @@
 //! [`Ledger`]: ledger::Connection
 
 use crate::{
-    asset::{Asset, AssetId, AssetMetadata, AssetValue},
+    asset::{Asset, AssetId, AssetList, AssetMetadata, AssetValue},
     transfer::{
         canonical::{Transaction, TransactionKind},
         Configuration, ReceivingKey,
@@ -128,6 +128,18 @@ where
     #[inline]
     pub fn contains(&self, asset: Asset) -> bool {
         self.assets.contains(asset)
+    }
+
+    /// Returns `true` if `self` contains at least every asset in `assets`. Assets are combined
+    /// first by [`AssetId`] before checking for membership.
+    #[inline]
+    pub fn contains_all<I>(&self, assets: I) -> bool
+    where
+        I: IntoIterator<Item = Asset>,
+    {
+        AssetList::from_iter(assets)
+            .into_iter()
+            .all(|asset| self.contains(asset))
     }
 
     /// Returns a shared reference to the balance state associated to `self`.

--- a/manta-pay/src/bin/simulation.rs
+++ b/manta-pay/src/bin/simulation.rs
@@ -34,7 +34,7 @@ pub fn main() {
     )
     .expect("Failed to generate contexts.");
     match tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(4)
+        .worker_threads(6)
         .build()
     {
         Ok(runtime) => runtime.block_on(async {

--- a/manta-pay/src/simulation/mod.rs
+++ b/manta-pay/src/simulation/mod.rs
@@ -88,6 +88,7 @@ impl Simulation {
         test::Config {
             actor_count: self.actor_count,
             actor_lifetime: self.actor_lifetime,
+            action_distribution: Default::default(),
         }
     }
 


### PR DESCRIPTION
Adds a recovery action to the simulation so that we can test dynamically against signers and wallets getting out of sync