### PR TITLE
fix: remove the package flag in benchmark CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,7 +7,7 @@ env:
   RUST_BACKTRACE: full
 jobs:
   cargo-bench:
-    name: Bench With Cargo (${{ matrix.os }} + ${{ matrix.channel }})
+    name: Cargo Bench (${{ matrix.os }} + ${{ matrix.channel }})
     strategy:
       fail-fast: false
       matrix:
@@ -24,7 +24,7 @@ jobs:
       - run: rustup update ${{ matrix.channel }} && rustup default ${{ matrix.channel }}
       - run: cargo bench --workspace --all-features
   wasm-pack-bench:
-    name: Bench With Wasm-Pack (${{ matrix.os }} + ${{ matrix.channel }})
+    name: WASM-Pack Bench (${{ matrix.os }} + ${{ matrix.channel }} + ${{ matrix.package }})
     strategy:
       fail-fast: false
       matrix:
@@ -35,9 +35,11 @@ jobs:
         channel:
           - stable
           - nightly
+        package:
+          - manta-benchmark
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - run: rustup update ${{ matrix.channel }} && rustup default ${{ matrix.channel }}
       - run: cargo install wasm-pack
-      - run: wasm-pack test --headless --chrome --release --package manta-benchmark
+      - run: wasm-pack test --headless --chrome --release ${{ matrix.package }}


### PR DESCRIPTION
Removes the redundant `--package` flag when running the `wasm-pack` benchmarks.