### PR TITLE
fix: remove download dependency from `manta-benchmark`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- [\#103](https://github.com/Manta-Network/manta-rs/pull/103) Remove download dependency from `manta-benchmark`
 
 ### Security
 

--- a/manta-pay/Cargo.toml
+++ b/manta-pay/Cargo.toml
@@ -49,9 +49,6 @@ arkworks = [
     "ark-std",
 ]
 
-# Enable Download Parameters
-download = ["manta-parameters/download"]
-
 # Enable Groth16 ZKP System
 groth16 = ["ark-groth16", "ark-snark", "arkworks"]
 
@@ -127,7 +124,6 @@ futures = { version = "0.3.21", optional = true, default-features = false }
 indexmap = { version = "1.8.2", optional = true, default-features = false }
 manta-accounting = { path = "../manta-accounting", default-features = false }
 manta-crypto = { path = "../manta-crypto", default-features = false }
-manta-parameters = { path = "../manta-parameters", optional = true, default-features = false }
 manta-util = { path = "../manta-util", default-features = false }
 parking_lot = { version = "0.12.1", optional = true, default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
@@ -145,4 +141,5 @@ ws_stream_wasm = { version = "0.7.3", optional = true, default-features = false 
 
 [dev-dependencies]
 manta-crypto = { path = "../manta-crypto", default-features = false, features = ["getrandom"] }
-manta-pay = { path = ".", default-features = false, features = ["download", "groth16", "scale", "scale-std", "std", "test"] }
+manta-parameters = { path = "../manta-parameters", default-features = false, features = ["download"] }
+manta-pay = { path = ".", default-features = false, features = ["groth16", "scale", "scale-std", "std", "test"] }

--- a/manta-pay/Cargo.toml
+++ b/manta-pay/Cargo.toml
@@ -49,6 +49,9 @@ arkworks = [
     "ark-std",
 ]
 
+# Enable Download Parameters
+download = ["manta-parameters/download"]
+
 # Enable Groth16 ZKP System
 groth16 = ["ark-groth16", "ark-snark", "arkworks"]
 
@@ -86,7 +89,7 @@ simulation = [
 std = ["manta-accounting/std", "manta-util/std"]
 
 # Testing Frameworks
-test = ["anyhow", "manta-accounting/test", "manta-crypto/test", "manta-parameters/download", "tempfile"]
+test = ["anyhow", "manta-accounting/test", "manta-crypto/test", "tempfile"]
 
 # Wallet
 wallet = ["bip32", "manta-crypto/getrandom", "std"]
@@ -142,4 +145,4 @@ ws_stream_wasm = { version = "0.7.3", optional = true, default-features = false 
 
 [dev-dependencies]
 manta-crypto = { path = "../manta-crypto", default-features = false, features = ["getrandom"] }
-manta-pay = { path = ".", default-features = false, features = ["groth16", "scale", "scale-std", "std", "test"] }
+manta-pay = { path = ".", default-features = false, features = ["download", "groth16", "scale", "scale-std", "std", "test"] }

--- a/manta-pay/src/test/mod.rs
+++ b/manta-pay/src/test/mod.rs
@@ -23,7 +23,7 @@
 // #[cfg_attr(doc_cfg, doc(cfg(feature = "simulation")))]
 // pub mod simulation;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "download"))]
 pub mod compatibility;
 
 #[cfg(test)]

--- a/manta-pay/src/test/mod.rs
+++ b/manta-pay/src/test/mod.rs
@@ -23,7 +23,7 @@
 // #[cfg_attr(doc_cfg, doc(cfg(feature = "simulation")))]
 // pub mod simulation;
 
-#[cfg(all(test, feature = "download"))]
+#[cfg(test)]
 pub mod compatibility;
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Fix compatibility issue between `manta-benchmark` and `manta-parameters/download`.

## Details

`openssl` is not well-supported yet in `wasm`. `manta-parameters` use `openssl` to download lfs files while `manta-benchmark` contains `wasm` benchmarks. Currently, `manta-benchmark` implicitly imports `openssl` through `manta-pay/test` which imports `manta-parameters/download`.

In this PR, we separate the feature `manta-parameters/download` from `manta-pay/test` to avoid this implicit import of `openssl` in `manta-benchmark`.

Issue: #104 

---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-rs/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
- [x] Checked that changes and commits conform to the standards outlined in [`CONTRIBUTING.md`](https://github.com/manta-network/manta-rs/blob/main/CONTRIBUTING.md).
