### PR TITLE
feat: add more parameter loading utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [\#90](https://github.com/Manta-Network/manta-rs/pull/90) Add Binary Compatibility Test for `manta-pay`
 - [\#102](https://github.com/Manta-Network/manta-rs/pull/102) Add concrete parameters to `manta-parameters`
 - [\#106](https://github.com/Manta-Network/manta-rs/pull/106) Add `load_parameter` as a library function
+- [\#128](https://github.com/Manta-Network/manta-rs/pull/128) Add more parameter loading utilities
 
 ### Fixed
 - [\#103](https://github.com/Manta-Network/manta-rs/pull/103) Remove download dependency from `manta-benchmark`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Added
+- [\#128](https://github.com/Manta-Network/manta-rs/pull/128) Add more parameter loading utilities
 
 ### Changed
 
@@ -21,7 +22,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [\#90](https://github.com/Manta-Network/manta-rs/pull/90) Add Binary Compatibility Test for `manta-pay`
 - [\#102](https://github.com/Manta-Network/manta-rs/pull/102) Add concrete parameters to `manta-parameters`
 - [\#106](https://github.com/Manta-Network/manta-rs/pull/106) Add `load_parameter` as a library function
-- [\#128](https://github.com/Manta-Network/manta-rs/pull/128) Add more parameter loading utilities
 
 ### Fixed
 - [\#103](https://github.com/Manta-Network/manta-rs/pull/103) Remove download dependency from `manta-benchmark`

--- a/manta-accounting/src/transfer/test.rs
+++ b/manta-accounting/src/transfer/test.rs
@@ -407,6 +407,7 @@ pub fn assert_valid_proof<C>(verifying_context: &VerifyingContext<C>, post: &Tra
 where
     C: Configuration,
     <C::ProofSystem as ProofSystem>::Error: Debug,
+    TransferPost<C>: Debug,
 {
     assert!(
         C::ProofSystem::verify(
@@ -415,6 +416,7 @@ where
             &post.validity_proof,
         )
         .expect("Unable to verify proof."),
-        "Invalid proof.",
+        "Invalid proof: {:?}",
+        post,
     );
 }

--- a/manta-pay/Cargo.toml
+++ b/manta-pay/Cargo.toml
@@ -50,7 +50,7 @@ arkworks = [
 ]
 
 # Enable Download Parameters
-download = ["manta-parameters", "std"]
+download = ["manta-parameters/download", "std"]
 
 # Enable Groth16 ZKP System
 groth16 = ["ark-groth16", "ark-snark", "arkworks"]
@@ -86,7 +86,7 @@ simulation = [
 std = ["manta-accounting/std", "manta-util/std"]
 
 # Testing Frameworks
-test = ["manta-accounting/test", "manta-crypto/test", "tempfile"]
+test = ["manta-accounting/test", "manta-crypto/test", "manta-parameters", "tempfile"]
 
 # Wallet
 wallet = ["bip32", "manta-crypto/getrandom", "std"]
@@ -123,7 +123,7 @@ futures = { version = "0.3.21", optional = true, default-features = false }
 indexmap = { version = "1.8.2", optional = true, default-features = false }
 manta-accounting = { path = "../manta-accounting", default-features = false }
 manta-crypto = { path = "../manta-crypto", default-features = false }
-manta-parameters = { path = "../manta-parameters", optional = true, default-features = false, features = ["download"] }
+manta-parameters = { path = "../manta-parameters", optional = true, default-features = false }
 manta-util = { path = "../manta-util", default-features = false }
 parking_lot = { version = "0.12.1", optional = true, default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }


### PR DESCRIPTION
Signed-off-by: Boyuan Feng <bfeng9@wisc.edu>

## Description
Add more parameter loading utilities in `manta-pay` such that repos such as `Manta` an `manta-signer` do not need to touch `manta-parameters`.

This PR is the first step to solving https://github.com/Manta-Network/manta-rs/issues/110.

---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-rs/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
- [x] Checked that changes and commits conform to the standards outlined in [`CONTRIBUTING.md`](https://github.com/manta-network/manta-rs/blob/main/CONTRIBUTING.md).
