### PR TITLE
chore: fix badge error when badgen.net queries action state

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # manta-rs
 
-[![Workflow Status](https://flat.badgen.net/github/checks/Manta-Network/manta-rs?label=workflow)](https://github.com/Manta-Network/manta-rs/actions)
+[![Workflow Status](https://flat.badgen.net/github/status/Manta-Network/manta-rs?label=workflow)](https://github.com/Manta-Network/manta-rs/actions)
 [![Latest Release](https://flat.badgen.net/github/release/Manta-Network/manta-rs)](https://github.com/Manta-Network/manta-rs/releases)
 
 _Rust Crates for the Manta Network Ecosystem_


### PR DESCRIPTION
Fixes a README badge error whenever the CI action is pending.

---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
- [x] Checked that changes and commits conform to the standards outlined in [`CONTRIBUTING.md`](https://github.com/manta-network/manta-rs/blob/main/CONTRIBUTING.md).
