### PR TITLE
feat: add more pre-check to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,6 @@ env:
   RUSTFLAGS: -D warnings -A unknown-lints
   RUST_BACKTRACE: full
 jobs:
-  format:
-    name: Format
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - run: rustup update nightly && rustup default nightly && rustup component add rustfmt
-    - run: cargo fmt --all -- --check
   workspace-hack-check:
     name: Workspace Hack Check
     runs-on: ubuntu-latest
@@ -31,9 +24,15 @@ jobs:
       - run: cargo hakari verify
       - run: cargo hakari generate --diff
       - run: cargo hakari manage-deps --dry-run
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: rustup update nightly && rustup default nightly && rustup component add rustfmt
+    - run: cargo fmt --all -- --check
   docs:
     name: Docs
-    needs: [format, workspace-hack-check]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -41,7 +40,7 @@ jobs:
       - run: RUSTDOCFLAGS="-D warnings --cfg doc_cfg" cargo +nightly doc --workspace --all-features --no-deps --document-private-items
   lint:
     name: Lint (${{ matrix.os }} + ${{ matrix.channel }})
-    needs: [format, workspace-hack-check, docs]
+    needs: [workspace-hack-check, format, docs]
     strategy:
       fail-fast: false
       matrix:
@@ -61,7 +60,7 @@ jobs:
       - run: cargo hack clippy --workspace --feature-powerset --tests
   test:
     name: Test (${{ matrix.os }} + ${{ matrix.channel }})
-    needs: [format, workspace-hack-check, docs]
+    needs: [workspace-hack-check, format, docs]
     strategy:
       fail-fast: false
       matrix:
@@ -80,7 +79,7 @@ jobs:
       - run: cargo nextest run --workspace --release --all-features
   compile-bench:
     name: Compile Bench (${{ matrix.os }} + ${{ matrix.channel }})
-    needs: [format, workspace-hack-check, docs]
+    needs: [workspace-hack-check, format, docs]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,28 +21,27 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update nightly && rustup default nightly && rustup component add rustfmt
     - run: cargo fmt --all -- --check
-  test:
-    name: Test (${{ matrix.os }} + ${{ matrix.channel }})
-    needs: format
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-          - windows-latest
-        channel:
-          - stable
-          - nightly
-    runs-on: ${{ matrix.os }}
+  workspace-hack-check:
+    name: Workspace Hack Check
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: rustup update ${{ matrix.channel }} && rustup default ${{ matrix.channel }}
-      - run: cargo install cargo-nextest
-      - run: cargo nextest run --workspace --release --all-features
+      - run: rustup update nightly && rustup default nightly
+      - run: cargo install cargo-hakari
+      - run: cargo hakari verify
+      - run: cargo hakari generate --diff
+      - run: cargo hakari manage-deps --dry-run
+  docs:
+    name: Docs
+    needs: [format, workspace-hack-check]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup update nightly && rustup default nightly
+      - run: RUSTDOCFLAGS="-D warnings --cfg doc_cfg" cargo +nightly doc --workspace --all-features --no-deps --document-private-items
   lint:
     name: Lint (${{ matrix.os }} + ${{ matrix.channel }})
-    needs: format
+    needs: [format, workspace-hack-check, docs]
     strategy:
       fail-fast: false
       matrix:
@@ -60,17 +59,28 @@ jobs:
       - run: cargo hack clippy --workspace --feature-powerset --bins
       - run: cargo hack clippy --workspace --feature-powerset --examples
       - run: cargo hack clippy --workspace --feature-powerset --tests
-  docs:
-    name: Docs
-    needs: format
-    runs-on: ubuntu-latest
+  test:
+    name: Test (${{ matrix.os }} + ${{ matrix.channel }})
+    needs: [format, workspace-hack-check, docs]
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        channel:
+          - stable
+          - nightly
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - run: rustup update nightly && rustup default nightly
-      - run: RUSTDOCFLAGS="-D warnings --cfg doc_cfg" cargo +nightly doc --workspace --all-features --no-deps --document-private-items
+      - run: rustup update ${{ matrix.channel }} && rustup default ${{ matrix.channel }}
+      - run: cargo install cargo-nextest
+      - run: cargo nextest run --workspace --release --all-features
   compile-bench:
     name: Compile Bench (${{ matrix.os }} + ${{ matrix.channel }})
-    needs: format
+    needs: [format, workspace-hack-check, docs]
     strategy:
       fail-fast: false
       matrix:
@@ -86,13 +96,3 @@ jobs:
       - uses: actions/checkout@v3
       - run: rustup update ${{ matrix.channel }} && rustup default ${{ matrix.channel }}
       - run: cargo bench --workspace --no-run --all-features
-  workspace-hack-check:
-    name: Workspace Hack Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - run: rustup update nightly && rustup default nightly
-      - run: cargo install cargo-hakari
-      - run: cargo hakari verify
-      - run: cargo hakari generate --diff
-      - run: cargo hakari manage-deps --dry-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [\#145](https://github.com/Manta-Network/manta-rs/pull/145) Add `cargo-hakari` and `cargo-nextest` to speed up CI pipeline
 
 ### Changed
-- [\#152](https://github.com/Manta-Network/manta-rs/pull/152) Made `format` and `docs` prerequisites for the rest of the CI pipeline
+- [\#152](https://github.com/Manta-Network/manta-rs/pull/152) Make `format` and `docs` as prerequisites for the rest of the CI pipeline
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [\#145](https://github.com/Manta-Network/manta-rs/pull/145) Add `cargo-hakari` and `cargo-nextest` to speed up CI pipeline
 
 ### Changed
+- [\#152](https://github.com/Manta-Network/manta-rs/pull/152) Made `format` and `docs` prerequisites for the rest of the CI pipeline
 
 ### Deprecated
 

--- a/manta-util/Cargo.toml
+++ b/manta-util/Cargo.toml
@@ -40,6 +40,6 @@ std = ["alloc"]
 [dependencies]
 crossbeam-channel = { version = "0.5.4", optional = true, default-features = false }
 rayon = { version = "1.5.3", optional = true, default-features = false }
-serde = { version = "1.0.137", optional = true, default-features = false, features = ["derive"] }
+serde = { version = "1.0.138", optional = true, default-features = false, features = ["derive"] }
 serde_with = { version = "1.14.0", optional = true, default-features = false, features = ["macros"] }
 manta-workspace-hack = { version = "0.1.0", path = "../manta-workspace-hack" }

--- a/manta-util/src/codec.rs
+++ b/manta-util/src/codec.rs
@@ -433,7 +433,7 @@ impl Write for Vec<u8> {
     fn write(&mut self, input: &mut &[u8]) -> Result<usize, Self::Error> {
         let len = input.len();
         self.reserve(len);
-        self.extend_from_slice(*input);
+        self.extend_from_slice(input);
         Ok(len)
     }
 

--- a/manta-workspace-hack/Cargo.toml
+++ b/manta-workspace-hack/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = { version = "1.0.58", features = ["std"] }
 bitflags = { version = "1.3.2" }
 blake3 = { version = "1.3.1", default-features = false, features = ["digest", "std"] }
 block-buffer = { version = "0.9.0", default-features = false, features = ["block-padding"] }
-crypto-common = { version = "0.1.3", default-features = false, features = ["std"] }
+crypto-common = { version = "0.1.4", default-features = false, features = ["std"] }
 digest-93f6ce9d446188ac = { package = "digest", version = "0.10.3", features = ["alloc", "block-buffer", "core-api", "mac", "std", "subtle"] }
 digest-274715c4dabd11b0 = { package = "digest", version = "0.9.0", default-features = false, features = ["alloc", "std"] }
 futures = { version = "0.3.21", features = ["alloc", "async-await", "executor", "futures-executor", "std"] }
@@ -40,7 +40,7 @@ ppv-lite86 = { version = "0.2.16", default-features = false, features = ["simd",
 rand = { version = "0.8.5", features = ["alloc", "getrandom", "libc", "rand_chacha", "std", "std_rng"] }
 rand_chacha = { version = "0.3.1", default-features = false, features = ["std"] }
 rand_core = { version = "0.6.3", default-features = false, features = ["alloc", "getrandom", "std"] }
-serde = { version = "1.0.137", features = ["alloc", "derive", "serde_derive", "std"] }
+serde = { version = "1.0.138", features = ["alloc", "derive", "serde_derive", "std"] }
 serde_json = { version = "1.0.82", features = ["alloc", "std"] }
 sha2 = { version = "0.9.9", features = ["std"] }
 standback = { version = "0.2.17", default-features = false, features = ["std"] }
@@ -53,12 +53,12 @@ zeroize = { version = "1.4.3", default-features = false, features = ["alloc", "z
 anyhow = { version = "1.0.58", features = ["std"] }
 blake3 = { version = "1.3.1", default-features = false, features = ["digest", "std"] }
 cc = { version = "1.0.73", default-features = false, features = ["jobserver", "parallel"] }
-crypto-common = { version = "0.1.3", default-features = false, features = ["std"] }
+crypto-common = { version = "0.1.4", default-features = false, features = ["std"] }
 digest-93f6ce9d446188ac = { package = "digest", version = "0.10.3", features = ["alloc", "block-buffer", "core-api", "mac", "std", "subtle"] }
 generic-array = { version = "0.14.5", default-features = false, features = ["more_lengths"] }
 log = { version = "0.4.17", default-features = false, features = ["kv_unstable", "kv_unstable_std", "std", "value-bag"] }
 num-traits = { version = "0.2.15", features = ["i128", "libm", "std"] }
-serde = { version = "1.0.137", features = ["alloc", "derive", "serde_derive", "std"] }
+serde = { version = "1.0.138", features = ["alloc", "derive", "serde_derive", "std"] }
 standback = { version = "0.2.17", default-features = false, features = ["std"] }
 subtle = { version = "2.4.1", default-features = false, features = ["i128"] }
 syn = { version = "1.0.98", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }


### PR DESCRIPTION
Adds `workspace-hack-check` and `docs` as pre-checks for the rest of the CI pipeline.

<img width="671" alt="Screen Shot 2022-07-03 at 20 37 57" src="https://user-images.githubusercontent.com/9126085/177063315-486c739e-e30a-488d-b083-cf0365d9ed65.png">

---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-rs/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
- [x] Checked that changes and commits conform to the standards outlined in [`CONTRIBUTING.md`](https://github.com/manta-network/manta-rs/blob/main/CONTRIBUTING.md).
