### PR TITLE
feat: add `.gitignore` and `README.md` support to `manta-parameters`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - [\#212](https://github.com/Manta-Network/manta-rs/pull/212) Reduce the number of checks when computing `is_identity` and `is_symmetric` on matrices
+- [\#220](https://github.com/Manta-Network/manta-rs/pull/220) Add support for `.gitignore` and `README.md` to `manta-parameters`
 
 ### Security
 

--- a/manta-parameters/Cargo.toml
+++ b/manta-parameters/Cargo.toml
@@ -47,5 +47,6 @@ walkdir = { version = "2.3.2", default-features = false }
 [build-dependencies]
 anyhow = { version = "1.0.62", default-features = false, features = ["std"] }
 blake3 = { version = "1.3.1", default-features = false, features = ["std"] }
+gitignore = { version = "1.0.7", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 walkdir = { version = "2.3.2", default-features = false }

--- a/manta-parameters/build.rs
+++ b/manta-parameters/build.rs
@@ -19,12 +19,13 @@
 use anyhow::{anyhow, bail, ensure, Result};
 use hex::FromHex;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     env,
     fs::{self, OpenOptions},
     io::{BufRead, BufReader},
     path::{Path, PathBuf},
 };
+use walkdir::{DirEntry, WalkDir};
 
 /// Returns the parent of `path` which should exist relative to `OUT_DIR`.
 #[inline]
@@ -112,24 +113,80 @@ fn compile_lfs(source: &Path, out_dir: &Path, checksums: &ChecksumMap) -> Result
     write_checksum(out_dir.join(source), get_checksum(checksums, source)?)
 }
 
+/// Checks that the filename in `entry` returns `true` when running `predicate`.
+#[inline]
+fn matches_predicate<P>(entry: &DirEntry, predicate: P) -> bool
+where
+    P: FnOnce(&str) -> bool,
+{
+    entry.file_name().to_str().map(predicate).unwrap_or(false)
+}
+
+/// Returns `true` when `entry` points to a hidden file.
+#[inline]
+fn is_hidden(entry: &DirEntry) -> bool {
+    matches_predicate(entry, |s| s.starts_with('.'))
+}
+
+/// Ignore Table
+type IgnoreTable = HashSet<PathBuf>;
+
+/// Builds the [`IgnoreTable`] for paths under `root`.
+#[inline]
+fn build_ignore_table<P>(root: P) -> Result<IgnoreTable>
+where
+    P: AsRef<Path>,
+{
+    let mut ignore_table = IgnoreTable::new();
+    for entry in WalkDir::new(root) {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_dir() && path.file_name().expect("") == ".gitignore" {
+            ignore_table.insert(
+                path.parent()
+                    .expect("The parent directory should exist.")
+                    .to_owned(),
+            );
+        }
+    }
+    Ok(ignore_table)
+}
+
+/// Returns `true` if `path` is ignored by the corresponding entry in the `ignore_table`.
+#[inline]
+fn should_ignore(path: &Path, ignore_table: &IgnoreTable) -> Result<bool> {
+    let parent = path.parent().expect("The parent directory should exist.");
+    if ignore_table.contains(parent) {
+        gitignore::File::new(&parent.join(".gitignore"))
+            .map_err(|e| anyhow!("Unable to parse `.gitignore` file: {:?}", e))?
+            .is_excluded(path)
+            .map_err(|e| anyhow!("Error while ignoring the file: {}: {:?}", path.display(), e))
+    } else {
+        Ok(false)
+    }
+}
+
 /// Loads all the files from `data` into the `OUT_DIR` directory for inclusion into the library.
 #[inline]
 fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=data");
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    println!("out_dir: {:?}", out_dir);
     let checksums = parse_checkfile("data.checkfile")?;
-    for file in walkdir::WalkDir::new("data") {
-        let file = file?;
-        let path = file.path();
-        if !path.is_dir() {
+    let ignore_table = build_ignore_table("data")?;
+    for entry in WalkDir::new("data")
+        .into_iter()
+        .filter_entry(|e| !is_hidden(e))
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_dir() && !should_ignore(path, &ignore_table)? {
             match path.extension() {
                 Some(extension) => match extension.to_str() {
                     Some("dat") => compile_dat(path, &out_dir, &checksums)?,
                     Some("lfs") => compile_lfs(path, &out_dir, &checksums)?,
-                    _ => bail!("Unsupported data file extension."),
+                    _ => bail!("Unsupported data file extension: {}.", path.display()),
                 },
-                _ => bail!("All data files must have an extension."),
+                _ => bail!("All data files must have an extension: {}.", path.display()),
             }
         }
     }

--- a/manta-parameters/build.rs
+++ b/manta-parameters/build.rs
@@ -184,6 +184,7 @@ fn main() -> Result<()> {
                 Some(extension) => match extension.to_str() {
                     Some("dat") => compile_dat(path, &out_dir, &checksums)?,
                     Some("lfs") => compile_lfs(path, &out_dir, &checksums)?,
+                    Some("md") => {}
                     _ => bail!("Unsupported data file extension: {}.", path.display()),
                 },
                 _ => bail!("All data files must have an extension: {}.", path.display()),


### PR DESCRIPTION
Signed-off-by: Brandon H. Gomes <bhgomes@pm.me>

Adds `.gitignore` support for `manta-parameters`. Files can now be added to the `data` directory without requiring them to be uploaded to GitHub by specifying them in a `.gitignore` file local to any of the subdirectories of the `data` directory. In this case, a `README.md` should be used to direct users to download the ignored files from an external service.

---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-rs/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
- [x] Checked that changes and commits conform to the standards outlined in [`CONTRIBUTING.md`](https://github.com/manta-network/manta-rs/blob/main/CONTRIBUTING.md).
- [x] Ran `cargo hakari generate` to update the `workspace-hack` system