### PR TITLE
Move arkworks curves to `manta-crypto`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [\#197](https://github.com/Manta-Network/manta-rs/pull/197) Add ECLAIR utilities for next circuit upgrade
 
 ### Changed
+- [\#247](https://github.com/Manta-Network/manta-rs/pull/247) Moved BLS12-381 and BN254 curves (and Edwards counterparts) to `manta-crypto`
 - [\#236](https://github.com/Manta-Network/manta-rs/pull/236) Moved `RatioProof` from `manta-trusted-setup` to `manta-crypto`
 - [\#180](https://github.com/Manta-Network/manta-rs/pull/180) Start moving to new `arkworks` backend for `manta-crypto`
 - [\#191](https://github.com/Manta-Network/manta-rs/pull/191) Move HTTP Utilities to `manta-util`

--- a/manta-benchmark/Cargo.toml
+++ b/manta-benchmark/Cargo.toml
@@ -44,13 +44,12 @@ name = "reclaim"
 harness = false
 
 [dependencies]
-ark-bls12-381 = { version = "0.3.0", default-features = false }
 ark-ec = { version = "0.3.0", default-features = false }
 ark-ff = { version = "0.3.0", default-features = false }
 getrandom = { version = "0.2.6", default-features = false, features = ["js"] }
 instant = { version = "0.1.12", default-features = false, features = [ "wasm-bindgen" ] }
 manta-accounting = { path = "../manta-accounting", default-features = false, features = ["test"] }
-manta-crypto = { path = "../manta-crypto", default-features = false, features = ["getrandom", "test"] }
+manta-crypto = { path = "../manta-crypto", default-features = false, features = ["ark-bls12-381", "getrandom", "test"] }
 manta-pay = { path = "../manta-pay", default-features = false, features = ["groth16", "test"] }
 wasm-bindgen = { version = "0.2.82", default-features = false }
 wasm-bindgen-test = { version = "0.3.30", default-features = false }

--- a/manta-benchmark/benches/ecc.rs
+++ b/manta-benchmark/benches/ecc.rs
@@ -16,12 +16,15 @@
 
 //! Elliptic Curve Cryptography Benchmarks
 
-use ark_bls12_381::{G1Affine, G1Projective};
 use core::iter::repeat_with;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use manta_benchmark::ecc;
-use manta_crypto::rand::OsRng;
+use manta_crypto::{
+    arkworks::bls12_381::{G1Affine, G1Projective},
+    rand::OsRng,
+};
 
+#[inline]
 fn affine_affine_addition(c: &mut Criterion) {
     let mut group = c.benchmark_group("bench");
     let mut rng = OsRng;
@@ -34,6 +37,7 @@ fn affine_affine_addition(c: &mut Criterion) {
     });
 }
 
+#[inline]
 fn projective_affine_addition(c: &mut Criterion) {
     let mut group = c.benchmark_group("bench");
     let mut rng = OsRng;
@@ -46,6 +50,7 @@ fn projective_affine_addition(c: &mut Criterion) {
     });
 }
 
+#[inline]
 fn projective_projective_addition(c: &mut Criterion) {
     let mut group = c.benchmark_group("bench");
     let mut rng = OsRng;
@@ -58,6 +63,7 @@ fn projective_projective_addition(c: &mut Criterion) {
     });
 }
 
+#[inline]
 fn affine_scalar_multiplication(c: &mut Criterion) {
     let mut group = c.benchmark_group("bench");
     let mut rng = OsRng;
@@ -70,6 +76,7 @@ fn affine_scalar_multiplication(c: &mut Criterion) {
     });
 }
 
+#[inline]
 fn projective_scalar_multiplication(c: &mut Criterion) {
     let mut group = c.benchmark_group("bench");
     let mut rng = OsRng;
@@ -82,6 +89,7 @@ fn projective_scalar_multiplication(c: &mut Criterion) {
     });
 }
 
+#[inline]
 fn projective_to_affine_normalization(c: &mut Criterion) {
     let mut group = c.benchmark_group("bench");
     let mut rng = OsRng;
@@ -93,6 +101,7 @@ fn projective_to_affine_normalization(c: &mut Criterion) {
     });
 }
 
+#[inline]
 fn batch_vector_projective_to_affine_normalization(c: &mut Criterion) {
     let mut group = c.benchmark_group("bench");
     let mut rng = OsRng;
@@ -109,6 +118,7 @@ fn batch_vector_projective_to_affine_normalization(c: &mut Criterion) {
     });
 }
 
+#[inline]
 fn naive_vector_projective_to_affine_normalization(c: &mut Criterion) {
     let mut group = c.benchmark_group("bench");
     let mut rng = OsRng;

--- a/manta-benchmark/src/ecc.rs
+++ b/manta-benchmark/src/ecc.rs
@@ -123,11 +123,11 @@ where
     point_vec.iter().map(P::into_affine).collect()
 }
 
+/// Testing Suite
 #[cfg(test)]
 mod test {
     use super::*;
-    use ark_bls12_381::G1Affine;
-    use manta_crypto::rand::OsRng;
+    use manta_crypto::{arkworks::bls12_381::G1Affine, rand::OsRng};
 
     /// Tests if affine-affine addition, affine-projective addition, and projective-projective
     /// addition give same results.

--- a/manta-crypto/Cargo.toml
+++ b/manta-crypto/Cargo.toml
@@ -35,9 +35,7 @@ arkworks = [
 ]
 
 # Dalek Cryptography Backend
-dalek = [
-    "ed25519-dalek",
-]
+dalek = ["ed25519-dalek"]
 
 # Enable `getrandom` Entropy Source
 getrandom = ["rand_core/getrandom"]
@@ -50,12 +48,28 @@ serde = [
 ]
 
 # Standard Library
-std = ["manta-util/std", "rand_chacha?/std"]
+std = [
+    "ark-bls12-381?/std",
+    "ark-bn254?/std",
+    "ark-ec?/std",
+    "ark-ed-on-bls12-381?/std",
+    "ark-ed-on-bn254?/std",
+    "ark-ff?/std",
+    "ark-r1cs-std?/std",
+    "ark-relations?/std",
+    "ark-serialize?/std",
+    "manta-util/std",
+    "rand_chacha?/std",
+]
 
 # Testing Frameworks
 test = []
 
 [dependencies]
+ark-bls12-381 = { version = "0.3.0", optional = true, default-features = false, features = ["curve"] }
+ark-bn254 = { version = "0.3.0", optional = true, default-features = false, features = ["curve"] }
+ark-ed-on-bls12-381 = { version = "0.3.0", optional = true, default-features = false, features = ["r1cs"] }
+ark-ed-on-bn254 = { version = "0.3.0", optional = true, default-features = false, features = ["r1cs"] }
 ark-ec = { version = "0.3.0", optional = true, default-features = false }
 ark-ff = { version = "0.3.0", optional = true, default-features = false }
 ark-r1cs-std = { version = "0.3.1", optional = true, default-features = false }
@@ -69,5 +83,4 @@ rand_chacha = { version = "0.3.1", optional = true, default-features = false }
 rand_core = { version = "0.6.3", default-features = false }
 
 [dev-dependencies]
-ark-bn254 = { version = "0.3.0", default-features = false, features = ["scalar_field"] }
 manta-crypto = { path = ".", default-features = false, features = ["getrandom"] }

--- a/manta-crypto/Cargo.toml
+++ b/manta-crypto/Cargo.toml
@@ -83,4 +83,4 @@ rand_chacha = { version = "0.3.1", optional = true, default-features = false }
 rand_core = { version = "0.6.3", default-features = false }
 
 [dev-dependencies]
-manta-crypto = { path = ".", default-features = false, features = ["getrandom"] }
+manta-crypto = { path = ".", default-features = false, features = ["ark-bn254", "getrandom"] }

--- a/manta-crypto/Cargo.toml
+++ b/manta-crypto/Cargo.toml
@@ -68,9 +68,9 @@ test = []
 [dependencies]
 ark-bls12-381 = { version = "0.3.0", optional = true, default-features = false, features = ["curve"] }
 ark-bn254 = { version = "0.3.0", optional = true, default-features = false, features = ["curve"] }
+ark-ec = { version = "0.3.0", optional = true, default-features = false }
 ark-ed-on-bls12-381 = { version = "0.3.0", optional = true, default-features = false, features = ["r1cs"] }
 ark-ed-on-bn254 = { version = "0.3.0", optional = true, default-features = false, features = ["r1cs"] }
-ark-ec = { version = "0.3.0", optional = true, default-features = false }
 ark-ff = { version = "0.3.0", optional = true, default-features = false }
 ark-r1cs-std = { version = "0.3.1", optional = true, default-features = false }
 ark-relations = { version = "0.3.0", optional = true, default-features = false }

--- a/manta-crypto/src/arkworks/ff.rs
+++ b/manta-crypto/src/arkworks/ff.rs
@@ -57,7 +57,10 @@ field_try_into! {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::rand::{OsRng, Rand, RngCore, Sample};
+    use crate::{
+        arkworks::bn254::Fr,
+        rand::{OsRng, Rand, RngCore, Sample},
+    };
     use alloc::vec::Vec;
     use core::fmt::Debug;
 
@@ -101,7 +104,7 @@ mod test {
         ($name:ident, $convert:ident, $type:tt) => {
             #[test]
             fn $name() {
-                assert_valid_integer_conversions::<ark_bn254::Fr, _, _, _, 0xFFFF>(
+                assert_valid_integer_conversions::<Fr, _, _, _, 0xFFFF>(
                     $convert,
                     vec![0, 1, 2, $type::MAX - 2, $type::MAX - 1, $type::MAX],
                     &mut OsRng,

--- a/manta-crypto/src/arkworks/mod.rs
+++ b/manta-crypto/src/arkworks/mod.rs
@@ -21,6 +21,18 @@ pub use ark_r1cs_std as r1cs_std;
 pub use ark_relations as relations;
 pub use ark_serialize as serialize;
 
+#[cfg(feature = "ark-bls12-381")]
+pub use ark_bls12_381 as bls12_381;
+
+#[cfg(feature = "ark-bn254")]
+pub use ark_bn254 as bn254;
+
+#[cfg(feature = "ark-ed-on-bls12-381")]
+pub use ark_ed_on_bls12_381 as ed_on_bls12_381;
+
+#[cfg(feature = "ark-ed-on-bn254")]
+pub use ark_ed_on_bn254 as ed_on_bn254;
+
 pub mod algebra;
 pub mod constraint;
 pub mod ff;

--- a/manta-crypto/src/arkworks/pairing.rs
+++ b/manta-crypto/src/arkworks/pairing.rs
@@ -107,11 +107,14 @@ pub trait PairingEngineExt: PairingEngine {
 impl<E> PairingEngineExt for E where E: PairingEngine {}
 
 /// Testing Framework
-#[cfg(feature = "test")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
+#[cfg(any(feature = "test", test))]
+#[cfg_attr(doc_cfg, doc(cfg(any(feature = "test", test))))]
 pub mod test {
     use super::*;
     use crate::arkworks::ec::ProjectiveCurve;
+
+    #[cfg(test)]
+    use crate::rand::{OsRng, Rand};
 
     /// Asserts that `g1` and `g1*scalar` are in the same ratio as `g2` and `g2*scalar`.
     #[inline]
@@ -124,5 +127,29 @@ pub mod test {
             (g1.mul(scalar).into_affine(), g2)
         )
         .is_some());
+    }
+
+    /// Checks that BLS12-381 has a valid pairing ratio.
+    #[cfg(feature = "ark-bls12-381")]
+    #[test]
+    fn bls12_381_has_valid_pairing_ratio() {
+        let mut rng = OsRng;
+        assert_valid_pairing_ratio::<crate::arkworks::bls12_381::Bls12_381>(
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+        );
+    }
+
+    /// Checks that BN254 has a valid pairing ratio.
+    #[cfg(feature = "ark-bn254")]
+    #[test]
+    fn bn254_has_valid_pairing_ratio() {
+        let mut rng = OsRng;
+        assert_valid_pairing_ratio::<crate::arkworks::bn254::Bn254>(
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+        );
     }
 }

--- a/manta-parameters/Cargo.toml
+++ b/manta-parameters/Cargo.toml
@@ -32,8 +32,8 @@ download = ["anyhow", "attohttpc", "std"]
 std = ["anyhow?/std"]
 
 [dependencies]
-anyhow = { version = "1.0.62", optional = true, default-features = false }
-attohttpc = { version = "0.19.1", optional = true }
+anyhow = { version = "1.0.64", optional = true, default-features = false }
+attohttpc = { version = "0.22.0", optional = true }
 blake3 = { version = "1.3.1", default-features = false }
 
 [dev-dependencies]
@@ -44,7 +44,7 @@ tempfile = { version = "3.3.0", default-features = false }
 walkdir = { version = "2.3.2", default-features = false }
 
 [build-dependencies]
-anyhow = { version = "1.0.62", default-features = false, features = ["std"] }
+anyhow = { version = "1.0.64", default-features = false, features = ["std"] }
 blake3 = { version = "1.3.1", default-features = false, features = ["std"] }
 gitignore = { version = "1.0.7", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }

--- a/manta-pay/Cargo.toml
+++ b/manta-pay/Cargo.toml
@@ -40,6 +40,8 @@ required-features = ["clap", "groth16", "simulation"]
 # Enable Arkworks Backend
 arkworks = [
     "ark-std",
+    "manta-crypto/ark-bls12-381",
+    "manta-crypto/ark-ed-on-bls12-381",
     "manta-crypto/arkworks",
 ]
 

--- a/manta-pay/Cargo.toml
+++ b/manta-pay/Cargo.toml
@@ -67,9 +67,9 @@ serde = ["manta-accounting/serde", "manta-crypto/serde"]
 simulation = [
     "indexmap",
     "parking_lot",
-    "rayon",
+    "manta-util/rayon",
     "test",
-    "tide",
+    "manta-util/tide",
     "tokio/io-std",
     "tokio/io-util",
     "tokio/macros",
@@ -106,23 +106,20 @@ ark-std = { version = "0.3.0", optional = true, default-features = false }
 bip32 = { version = "0.3.0", optional = true, default-features = false, features = ["bip39", "secp256k1"] }
 blake2 = { version = "0.10.4", default-features = false }
 bs58 = { version = "0.4.0", optional = true, default-features = false, features = ["alloc"] }
-clap = { version = "3.2.17", optional = true, default-features = false, features = ["color", "derive", "std", "suggestions", "unicode", "wrap_help"] }
+clap = { version = "3.2.20", optional = true, default-features = false, features = ["color", "derive", "std", "suggestions", "unicode", "wrap_help"] }
 derivative = { version = "2.2.0", default-features = false, features = ["use_core"] }
-futures = { version = "0.3.21", optional = true, default-features = false }
-indexmap = { version = "1.8.2", optional = true, default-features = false }
+futures = { version = "0.3.24", optional = true, default-features = false }
+indexmap = { version = "1.9.1", optional = true, default-features = false }
 manta-accounting = { path = "../manta-accounting", default-features = false }
 manta-crypto = { path = "../manta-crypto", default-features = false }
 manta-parameters = { path = "../manta-parameters", optional = true, default-features = false }
 manta-util = { path = "../manta-util", default-features = false }
 parking_lot = { version = "0.12.1", optional = true, default-features = false }
-rand_chacha = { version = "0.3.1", default-features = false }
-rayon = { version = "1.5.1", optional = true, default-features = false }
 scale-codec = { package = "parity-scale-codec", version = "3.1.2", optional = true, default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "2.1.2", optional = true, default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.85", optional = true, default-features = false, features = ["alloc"] }
 tempfile = { version = "3.3.0", optional = true, default-features = false }
-tide = { version = "0.16.0", optional = true, default-features = false, features = ["h1-server"] }
-tokio = { version = "1.20.1", optional = true, default-features = false }
+tokio = { version = "1.21.0", optional = true, default-features = false }
 tokio-tungstenite = { version = "0.17.2", optional = true, default-features = false, features = ["native-tls"] }
 ws_stream_wasm = { version = "0.7.3", optional = true, default-features = false }
 

--- a/manta-pay/Cargo.toml
+++ b/manta-pay/Cargo.toml
@@ -111,7 +111,7 @@ derivative = { version = "2.2.0", default-features = false, features = ["use_cor
 futures = { version = "0.3.24", optional = true, default-features = false }
 indexmap = { version = "1.9.1", optional = true, default-features = false }
 manta-accounting = { path = "../manta-accounting", default-features = false }
-manta-crypto = { path = "../manta-crypto", default-features = false }
+manta-crypto = { path = "../manta-crypto", default-features = false, features = ["rand_chacha"] }
 manta-parameters = { path = "../manta-parameters", optional = true, default-features = false }
 manta-util = { path = "../manta-util", default-features = false }
 parking_lot = { version = "0.12.1", optional = true, default-features = false }

--- a/manta-pay/Cargo.toml
+++ b/manta-pay/Cargo.toml
@@ -39,8 +39,6 @@ required-features = ["clap", "groth16", "simulation"]
 [features]
 # Enable Arkworks Backend
 arkworks = [
-    "ark-bls12-381",
-    "ark-ed-on-bls12-381",
     "ark-std",
     "manta-crypto/arkworks",
 ]
@@ -100,8 +98,6 @@ websocket = [
 
 [dependencies]
 aes-gcm = { version = "0.9.4", default-features = false, features = ["aes", "alloc"] }
-ark-bls12-381 = { version = "0.3.0", optional = true, default-features = false, features = ["curve"] }
-ark-ed-on-bls12-381 = { version = "0.3.0", optional = true, default-features = false, features = ["r1cs"] }
 ark-groth16 = { version = "0.3.0", optional = true, default-features = false }
 ark-snark = { version = "0.3.0", optional = true, default-features = false }
 ark-std = { version = "0.3.0", optional = true, default-features = false }

--- a/manta-pay/src/bin/measure.rs
+++ b/manta-pay/src/bin/measure.rs
@@ -21,13 +21,12 @@ use manta_crypto::{
     eclair::alloc::{mode::Secret, Allocate, Allocator},
     hash::ArrayHashFunction,
     key::agreement::{Agree, Derive},
-    rand::{Sample, SeedableRng},
+    rand::{ChaCha20Rng, Sample, SeedableRng},
 };
 use manta_pay::config::{
     Compiler, KeyAgreementScheme, KeyAgreementSchemeVar, Poseidon2, Poseidon2Var, Poseidon4,
     Poseidon4Var,
 };
-use rand_chacha::ChaCha20Rng;
 
 /// Runs some basic measurements of the circuit component sizes.
 #[inline]

--- a/manta-pay/src/config.rs
+++ b/manta-pay/src/config.rs
@@ -28,8 +28,6 @@ use blake2::{
     digest::{Update, VariableOutput},
     Blake2sVar,
 };
-use bls12_381::Bls12_381;
-use bls12_381_ed::constraints::EdwardsVar as Bls12_381_EdwardsVar;
 use manta_accounting::{
     asset::{Asset, AssetId, AssetValue},
     transfer,
@@ -38,6 +36,8 @@ use manta_crypto::{
     accumulator,
     algebra::DiffieHellman,
     arkworks::{
+        bls12_381::{self, Bls12_381},
+        ed_on_bls12_381::{self, constraints::EdwardsVar as Bls12_381_EdwardsVar},
         ff::ToConstraintField,
         serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError},
     },
@@ -66,19 +66,13 @@ use alloc::string::String;
 #[cfg(any(feature = "test", test))]
 use manta_crypto::rand::{Rand, RngCore, Sample};
 
-#[doc(inline)]
-pub use ark_bls12_381 as bls12_381;
-
-#[doc(inline)]
-pub use ark_ed_on_bls12_381 as bls12_381_ed;
-
-pub(crate) use bls12_381_ed::EdwardsProjective as Bls12_381_Edwards;
+pub(crate) use ed_on_bls12_381::EdwardsProjective as Bls12_381_Edwards;
 
 /// Pairing Curve Type
 pub type PairingCurve = Bls12_381;
 
 /// Embedded Scalar Field Type
-pub type EmbeddedScalarField = bls12_381_ed::Fr;
+pub type EmbeddedScalarField = ed_on_bls12_381::Fr;
 
 /// Embedded Scalar Type
 pub type EmbeddedScalar = ecc::arkworks::Scalar<Bls12_381_Edwards>;

--- a/manta-pay/src/crypto/constraint/arkworks/mod.rs
+++ b/manta-pay/src/crypto/constraint/arkworks/mod.rs
@@ -758,10 +758,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ark_bls12_381::Fr;
     use core::iter::repeat_with;
     use manta_crypto::{
-        arkworks::ff::BigInteger,
+        arkworks::{bls12_381::Fr, ff::BigInteger},
         eclair::alloc::Allocate,
         rand::{OsRng, Rand},
     };

--- a/manta-pay/src/crypto/poseidon/matrix.rs
+++ b/manta-pay/src/crypto/poseidon/matrix.rs
@@ -628,7 +628,7 @@ where
 mod test {
     use super::*;
     use crate::crypto::constraint::arkworks::Fp;
-    use ark_bls12_381::Fr;
+    use manta_crypto::arkworks::bls12_381::Fr;
 
     /// Checks if generating minor matrix is correct.
     #[test]

--- a/manta-pay/src/crypto/poseidon/mds.rs
+++ b/manta-pay/src/crypto/poseidon/mds.rs
@@ -265,9 +265,11 @@ where
 mod test {
     use super::*;
     use crate::crypto::{constraint::arkworks::Fp, poseidon::matrix::Matrix};
-    use ark_bls12_381::Fr;
     use manta_crypto::{
-        arkworks::ff::{field_new, UniformRand},
+        arkworks::{
+            bls12_381::Fr,
+            ff::{field_new, UniformRand},
+        },
         rand::OsRng,
     };
 

--- a/manta-pay/src/crypto/poseidon/round_constants.rs
+++ b/manta-pay/src/crypto/poseidon/round_constants.rs
@@ -79,8 +79,7 @@ where
 mod test {
     use super::*;
     use crate::crypto::constraint::arkworks::Fp;
-    use ark_bls12_381::Fr;
-    use manta_crypto::arkworks::ff::field_new;
+    use manta_crypto::arkworks::{bls12_381::Fr, ff::field_new};
 
     /// Checks if [`GrainLFSR`] matches hardcoded sage outputs.
     #[test]

--- a/manta-pay/src/parameters.rs
+++ b/manta-pay/src/parameters.rs
@@ -21,9 +21,8 @@ use crate::config::{
     Parameters, PrivateTransfer, ProofSystemError, Reclaim, UtxoAccumulatorModel,
     UtxoCommitmentScheme, VerifyingContext, VoidNumberCommitmentScheme,
 };
-use manta_crypto::rand::{Rand, SeedableRng};
+use manta_crypto::rand::{ChaCha20Rng, Rand, SeedableRng};
 use manta_util::codec::Decode;
-use rand_chacha::ChaCha20Rng;
 
 #[cfg(feature = "std")]
 use {

--- a/manta-pay/src/signer/base.rs
+++ b/manta-pay/src/signer/base.rs
@@ -35,8 +35,8 @@ use manta_accounting::{
 use manta_crypto::{
     arkworks::{ec::ProjectiveCurve, ff::PrimeField},
     key::kdf::KeyDerivationFunction,
-    merkle_tree,
-    merkle_tree::forest::Configuration,
+    merkle_tree::{self, forest::Configuration},
+    rand::ChaCha20Rng,
 };
 
 #[cfg(feature = "serde")]
@@ -89,7 +89,7 @@ impl wallet::signer::Configuration for Config {
         key::Map<TestnetKeySecret, HierarchicalKeyDerivationFunction>;
     type UtxoAccumulator = UtxoAccumulator;
     type AssetMap = HashAssetMap<AssetMapKey<Self>>;
-    type Rng = rand_chacha::ChaCha20Rng;
+    type Rng = ChaCha20Rng;
 }
 
 impl signer::Checkpoint<Config> for Checkpoint {

--- a/manta-pay/src/simulation/ledger/http/server.rs
+++ b/manta-pay/src/simulation/ledger/http/server.rs
@@ -26,8 +26,10 @@ use manta_accounting::{
     asset::AssetList,
     wallet::{ledger::ReadResponse, signer::SyncData},
 };
-use manta_util::serde::{de::DeserializeOwned, Serialize};
-use tide::{listener::ToListener, Body, Response};
+use manta_util::{
+    http::tide::{self, listener::ToListener, Body, Response},
+    serde::{de::DeserializeOwned, Serialize},
+};
 use tokio::{io, sync::RwLock};
 
 /// Ledger HTTP Server State

--- a/manta-pay/src/simulation/mod.rs
+++ b/manta-pay/src/simulation/mod.rs
@@ -35,8 +35,7 @@ use manta_accounting::{
         Error,
     },
 };
-use manta_crypto::rand::{CryptoRng, Rand, RngCore, SeedableRng};
-use rand_chacha::ChaCha20Rng;
+use manta_crypto::rand::{ChaCha20Rng, CryptoRng, Rand, RngCore, SeedableRng};
 use tokio::{
     io::{self, AsyncWriteExt},
     sync::RwLock,

--- a/manta-trusted-setup/Cargo.toml
+++ b/manta-trusted-setup/Cargo.toml
@@ -26,7 +26,7 @@ maintenance = { status = "actively-developed" }
 
 [features]
 # Perpetual Powers of Tau Ceremony
-ppot = ["ark-bn254"]
+ppot = ["manta-crypto/ark-bn254"]
 
 # Rayon Parallelization
 rayon = ["manta-util/rayon"]
@@ -45,10 +45,8 @@ std = ["manta-util/std"]
 test = ["manta-crypto/test"]
 
 [dependencies]
-ark-bn254 = { version = "0.3.0", optional = true, default-features = false, features = ["curve", "scalar_field"] }
 ark-groth16 = { version = "0.3.0", default-features = false }
 ark-poly = { version = "0.3.0", default-features = false }
-ark-relations = { version = "0.3.0", default-features = false }
 ark-std = { version = "0.3.0", default-features = false }
 bincode = { version = "1.3.3", optional = true, default-features = false }
 blake2 = { version = "0.10.4", default-features = false }
@@ -57,9 +55,6 @@ manta-crypto = { path = "../manta-crypto", default-features = false, features = 
 manta-util = { path = "../manta-util", default-features = false }
 
 [dev-dependencies]
-ark-bls12-381 = { version = "0.3.0", default-features = false, features = ["curve", "scalar_field"] }
-ark-bn254 = { version = "0.3.0", default-features = false, features = ["curve", "scalar_field"] }
-ark-r1cs-std = { version = "0.3.1", default-features = false }
 ark-snark = { version = "0.3.0", default-features = false }
 manta-accounting = { path = "../manta-accounting", default-features = false }
 manta-parameters = { path = "../manta-parameters", default-features = false, features = ["download"] }

--- a/manta-trusted-setup/Cargo.toml
+++ b/manta-trusted-setup/Cargo.toml
@@ -57,6 +57,7 @@ manta-util = { path = "../manta-util", default-features = false }
 [dev-dependencies]
 ark-snark = { version = "0.3.0", default-features = false }
 manta-accounting = { path = "../manta-accounting", default-features = false }
+manta-crypto = { path = "../manta-crypto", default-features = false, features = ["ark-bn254", "arkworks", "getrandom", "rand_chacha"] }
 manta-parameters = { path = "../manta-parameters", default-features = false, features = ["download"] }
 manta-pay = { path = "../manta-pay", default-features = false, features = ["groth16", "test"] }
 manta-trusted-setup = { path = ".", default-features = false, features = ["std", "test"] }

--- a/manta-trusted-setup/src/groth16/ppot/hashing.rs
+++ b/manta-trusted-setup/src/groth16/ppot/hashing.rs
@@ -20,10 +20,10 @@ use crate::{
     groth16::{kzg::G1, ppot::kzg::PerpetualPowersOfTauCeremony},
     util::{hash_to_group, BlakeHasher, Serializer},
 };
-use ark_bn254::{Fq, Fq2, G1Affine, G2Affine};
 use blake2::Digest;
 use manta_crypto::{
     arkworks::{
+        bn254::{self, Fq, Fq2, G1Affine, G2Affine},
         ec::{short_weierstrass_jacobian::GroupAffine, ProjectiveCurve, SWModelParameters},
         ff::{BigInteger256, Fp256, FpParameters, Zero},
         ratio::HashToGroup,
@@ -93,8 +93,8 @@ impl Sample<PpotDistribution> for Fq {
             let mut tmp = BigInteger256::sample(distribution, rng);
 
             // Mask away the unused bits at the beginning.
-            tmp.as_mut()[3] &= 0xffffffffffffffff >> ark_bn254::FqParameters::REPR_SHAVE_BITS;
-            if tmp < ark_bn254::FqParameters::MODULUS {
+            tmp.as_mut()[3] &= 0xffffffffffffffff >> bn254::FqParameters::REPR_SHAVE_BITS;
+            if tmp < bn254::FqParameters::MODULUS {
                 return Fp256::new(tmp);
             }
         }

--- a/manta-trusted-setup/src/groth16/ppot/kzg.rs
+++ b/manta-trusted-setup/src/groth16/ppot/kzg.rs
@@ -23,11 +23,11 @@ use crate::{
     },
     util::{BlakeHasher, Deserializer, Serializer},
 };
-use ark_bn254::{Bn254, Fr, G1Affine, G2Affine};
 use ark_std::io;
 use blake2::Digest;
 use core::marker::PhantomData;
 use manta_crypto::arkworks::{
+    bn254::{Bn254, Fr, G1Affine, G2Affine},
     ec::{AffineCurve, PairingEngine},
     pairing::Pairing,
     serialize::{CanonicalSerialize, Read, Write},

--- a/manta-trusted-setup/src/groth16/ppot/serialization.rs
+++ b/manta-trusted-setup/src/groth16/ppot/serialization.rs
@@ -24,10 +24,10 @@ use crate::{
     util::{from_error, Deserializer, Serializer},
 };
 use alloc::vec::Vec;
-use ark_bn254::{G1Affine, G2Affine, Parameters};
 use ark_std::io;
 use core::fmt;
 use manta_crypto::arkworks::{
+    bn254::{G1Affine, G2Affine, Parameters},
     ec::{
         bn::BnParameters, short_weierstrass_jacobian::GroupAffine, ModelParameters,
         SWModelParameters,

--- a/manta-trusted-setup/src/groth16/test/mod.rs
+++ b/manta-trusted-setup/src/groth16/test/mod.rs
@@ -25,15 +25,15 @@ use crate::{
     util::{BlakeHasher, HasDistribution, KZGBlakeHasher},
 };
 use alloc::vec::Vec;
-use ark_bn254::{Bn254, Fr, G1Affine, G2Affine};
 use ark_groth16::{Groth16, ProvingKey};
 use ark_snark::SNARK;
 use blake2::Digest;
 use manta_crypto::{
     arkworks::{
+        bn254::{Bn254, Fr, G1Affine, G2Affine},
         ec::{AffineCurve, PairingEngine},
         ff::{field_new, UniformRand},
-        pairing::{test::assert_valid_pairing_ratio, Pairing},
+        pairing::Pairing,
         r1cs_std::eq::EqGadget,
         ratio::test::assert_valid_ratio_proof,
         serialize::CanonicalSerialize,
@@ -233,17 +233,6 @@ where
         )
         .unwrap(),
         "Verify proof should succeed."
-    );
-}
-
-/// Tests if bls13_381 pairing ratio is valid.
-#[test]
-fn has_valid_bn254_pairing_ratio() {
-    let mut rng = OsRng;
-    assert_valid_pairing_ratio::<Bn254>(
-        <G1Affine as Sample<()>>::gen(&mut rng),
-        <G2Affine as Sample<()>>::gen(&mut rng),
-        Fr::gen(&mut rng),
     );
 }
 

--- a/manta-util/src/http/tide.rs
+++ b/manta-util/src/http/tide.rs
@@ -19,7 +19,7 @@
 use crate::serde::{de::DeserializeOwned, Serialize};
 use core::future::Future;
 
-pub use tide::{Body, Error, Request, Response, Server, StatusCode};
+pub use tide::{listener, Body, Error, Request, Response, Server, StatusCode};
 
 /// Generates the JSON body for the output of `f`, returning an HTTP reponse.
 #[inline]


### PR DESCRIPTION
Signed-off-by: Brandon H. Gomes <bhgomes@pm.me>

The following curves and related tests were moved to `manta-crypto`:

- [x] `ark-bls12-381`
- [x] `ark-bn254`
- [x] `ark-ed-on-bls12-381`
- [x] `ark-ed-on-bn254`

---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-rs/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
- [x] Checked that changes and commits conform to the standards outlined in [`CONTRIBUTING.md`](https://github.com/manta-network/manta-rs/blob/main/CONTRIBUTING.md).
