### PR TITLE
adding bool_to_optin and const_fn_trait_bound for rust nightly

### DIFF
--- a/manta-accounting/src/lib.rs
+++ b/manta-accounting/src/lib.rs
@@ -28,6 +28,7 @@
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![forbid(rustdoc::broken_intra_doc_links)]
 #![forbid(missing_docs)]
+#![feature(bool_to_option)]
 
 extern crate alloc;
 extern crate derive_more;

--- a/manta-crypto/src/lib.rs
+++ b/manta-crypto/src/lib.rs
@@ -20,6 +20,8 @@
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![forbid(rustdoc::broken_intra_doc_links)]
 #![forbid(missing_docs)]
+#![feature(bool_to_option)]
+#![feature(const_fn_trait_bound)]
 
 extern crate alloc;
 

--- a/manta-pay/src/lib.rs
+++ b/manta-pay/src/lib.rs
@@ -20,6 +20,7 @@
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![forbid(rustdoc::broken_intra_doc_links)]
 #![forbid(missing_docs)]
+#![feature(bool_to_option)]
 
 extern crate alloc;
 


### PR DESCRIPTION
When compiling in nightly rust, it requires us enable bool_to_option feature. Also since we using trait function with non-constant bound "pub const fn scalar_bits<C>() -> usize" we need to add #![feature(const_fn_trait_bound)] for nightly rust.
