### PR TITLE
fix: use correct release trigger for `upload-binaries.yml`

### DIFF
--- a/.github/workflows/upload-binaries.yml
+++ b/.github/workflows/upload-binaries.yml
@@ -1,11 +1,11 @@
----
+name: upload-binaries
 on:
   release:
-    types:
-      - created
+    types: [published]
+  workflow_dispatch:
 jobs:
   build:
-    name: build release binary
+    name: Build Release Binaries
     strategy:
       fail-fast: false
       matrix:
@@ -13,15 +13,13 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
-        channel:
-          - stable
-          - nightly
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - run: rustup update ${{ matrix.channel }}
-      - run: rustup default ${{ matrix.channel }}
-      - run: cargo build --release --verbose --package manta-trusted-setup --all-features --bin groth16_phase2_client
+      - run: rustup update stable
+      - run: rustup default stable
+      - run: rustup default
+      - run: cargo build --release --all-features --workspace
       - id: get_release
         uses: bruceadams/get-release@v1.2.3
         env:
@@ -33,8 +31,8 @@ jobs:
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: ./target/release/groth16_phase2_client
-          asset_name: groth16-phase2-client-${{ matrix.channel }}-macos
-          asset_content_type: application/octet-stream
+          asset_name: groth16-phase2-client-macos-latest
+          asset_content_type: application/binary
       - if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-release-asset@v1.0.2
         env:
@@ -42,14 +40,14 @@ jobs:
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: ./target/release/groth16_phase2_client
-          asset_name: groth16-phase2-client-${{ matrix.channel }}-ubuntu
-          asset_content_type: application/octet-stream
+          asset_name: groth16-phase2-client-ubuntu-latest
+          asset_content_type: application/binary
       - if: matrix.os == 'windows-latest'
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ./target/release/groth16_phase2_client
-          asset_name: groth16-phase2-client-${{ matrix.channel }}-windows
-          asset_content_type: application/octet-stream
+          asset_path: ./target/release/groth16_phase2_client.exe
+          asset_name: groth16-phase2-client-windows-latest.exe
+          asset_content_type: application/binary


### PR DESCRIPTION
Signed-off-by: Brandon H. Gomes <bhgomes@pm.me>

Use the correct release trigger for `upload-binaries.yml`

---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [ ] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-rs/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Checked that changes and commits conform to the standards outlined in [`CONTRIBUTING.md`](https://github.com/manta-network/manta-rs/blob/main/CONTRIBUTING.md).
