### PR TITLE
Fix: Update Release Number in TS Client Installer Script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 ### Changed
+- [\#274](https://github.com/Manta-Network/manta-rs/pull/274) Update TS client installer script to use release 0.5.6.
 
 ### Deprecated
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -71,7 +71,7 @@ main() {
             ;;
     esac
 
-    local _url="https://github.com/manta-network/manta-rs/releases/download/v0.5.5/manta-trusted-setup-${_arch}${_ext}"
+    local _url="https://github.com/manta-network/manta-rs/releases/download/v0.5.6/manta-trusted-setup-${_arch}${_ext}"
 
     printf "[INFO] Installing manta-trusted-setup for the ${_arch} target ... "
 


### PR DESCRIPTION
Now that the executable files of the TS client are available for download we can update the installer script to download the assets from Release 0.5.6.

---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-rs/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
- [x] Checked that changes and commits conform to the standards outlined in [`CONTRIBUTING.md`](https://github.com/manta-network/manta-rs/blob/main/CONTRIBUTING.md).
