### PR TITLE
Asset display fix

### DIFF
--- a/manta-accounting/src/asset.rs
+++ b/manta-accounting/src/asset.rs
@@ -67,7 +67,7 @@ use manta_util::{
 use manta_util::serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
-use std::{
+use self::std::{
     collections::hash_map::{Entry as HashMapEntry, HashMap, RandomState},
     hash::BuildHasher,
 };

--- a/manta-accounting/src/asset.rs
+++ b/manta-accounting/src/asset.rs
@@ -1082,7 +1082,7 @@ impl AssetMetadata {
     pub fn display_value<V>(&self, value: V, digits: u32) -> String
     where
         for<'v> &'v V: Div<u128, Output = u128>,
-        V: std::fmt::Display,
+        V: manta_crypto::arkworks::std::fmt::Display,
     {
         let value_length: u32 = value.to_string().len().try_into().unwrap();
         if value_length <= digits {
@@ -1102,7 +1102,7 @@ impl AssetMetadata {
     pub fn display<V>(&self, value: V, digits: u32) -> String
     where
         for<'v> &'v V: Div<u128, Output = u128>,
-        V: std::fmt::Display,
+        V: manta_crypto::arkworks::std::fmt::Display,
     {
         format!("{} {}", self.display_value(value, digits), self.symbol)
     }

--- a/manta-accounting/src/asset.rs
+++ b/manta-accounting/src/asset.rs
@@ -24,10 +24,10 @@
 #![allow(clippy::uninlined_format_args)] // NOTE: Clippy false positive https://github.com/rust-lang/rust-clippy/issues/9715 on Display implementation on Asset below
 
 use alloc::{
-    string::ToString,
     collections::btree_map::{BTreeMap, Entry as BTreeMapEntry},
     format,
     string::String,
+    string::ToString,
     vec,
     vec::Vec,
 };
@@ -61,7 +61,6 @@ use manta_util::{
     num::CheckedSub,
     SizeLimit,
 };
-
 
 #[cfg(feature = "serde")]
 use manta_util::serde::{Deserialize, Serialize};


### PR DESCRIPTION
Fixes an edge case for the asset metadata display function that did not consider values in the range of (1,0). For example, the value 0.01, and 0.1 were both being displayed as 0.1.
---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [ ] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-rs/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Checked that changes and commits conform to the standards outlined in [`CONTRIBUTING.md`](https://github.com/manta-network/manta-rs/blob/main/CONTRIBUTING.md).
