### PR TITLE
downgrade serde to make sdk compiles

### DIFF
--- a/manta-util/Cargo.toml
+++ b/manta-util/Cargo.toml
@@ -41,6 +41,6 @@ std = ["alloc", "crossbeam-channel?/std", "serde?/std"]
 crossbeam-channel = { version = "0.5.6", optional = true, default-features = false }
 rayon = { version = "1.5.3", optional = true, default-features = false }
 reqwest = { version = "0.11.13", optional = true, default-features = false, features = ["default-tls", "json"] }
-serde = { version = "1.0.152", optional = true, default-features = false, features = ["derive"] }
+serde = { version = "1.0.151", optional = true, default-features = false, features = ["derive"] }
 serde_with = { version = "1.14.0", optional = true, default-features = false, features = ["macros"] }
 tide = { version = "0.16.0", optional = true, default-features = false, features = ["h1-server"] }


### PR DESCRIPTION
Signed-off-by: zqhxuyuan <zqhxuyuan@gmail.com>

using v0.5.9 has compile error on sdk:
```
error: failed to select a version for `serde`.
    ... required by package `serde_json v1.0.91`
    ... which satisfies dependency `serde_json = "^1.0.91"` (locked to 1.0.91) of package `manta-wasm-wallet v1.5.1 (/Users/zqh/code/substrates/manta-sdk/manta-js/package/src/wallet/crate)`
versions that meet the requirements `^1.0.100` (locked to 1.0.151) are: 1.0.151

all possible versions conflict with previously selected packages.

  previously selected package `serde v1.0.152`
    ... which satisfies dependency `serde = "^1.0.152"` of package `manta-util v0.5.9 (https://github.com/manta-network/manta-rs.git?tag=v0.5.9#8a995e91)`
    ... which satisfies git dependency `manta-util` of package `manta-accounting v0.5.9 (https://github.com/manta-network/manta-rs.git?tag=v0.5.9#8a995e91)`
    ... which satisfies git dependency `manta-accounting` of package `manta-pay v0.5.9 (https://github.com/manta-network/manta-rs.git?tag=v0.5.9#8a995e91)`
    ... which satisfies git dependency `manta-pay` of package `manta-wasm-wallet v1.5.1 (/Users/zqh/code/substrates/manta-sdk/manta-js/package/src/wallet/crate)`
```

---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [ ] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-rs/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Checked that changes and commits conform to the standards outlined in [`CONTRIBUTING.md`](https://github.com/manta-network/manta-rs/blob/main/CONTRIBUTING.md).
