### PR TITLE
Key Dependent Signer Function APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Added
+- [\#319](https://github.com/Manta-Network/manta-rs/pull/319) Key-dependent signer function APIs.
 - [\#314](https://github.com/Manta-Network/manta-rs/pull/314) Prepares the signer export to wasm.
 - [\#289](https://github.com/Manta-Network/manta-rs/pull/289) AssetMetadata upgrade and NFT support.
 - [\#310](https://github.com/Manta-Network/manta-rs/pull/310) Add identity verification algorithm using ToPublic circuit

--- a/manta-accounting/src/transfer/utxo/protocol.rs
+++ b/manta-accounting/src/transfer/utxo/protocol.rs
@@ -2256,6 +2256,13 @@ where
     }
 }
 
+impl<C> cmp::Eq for AuthorizationContext<C>
+where
+    C: BaseConfiguration<Bool = bool>,
+    C::Group: cmp::PartialEq,
+{
+}
+
 impl<C, COM> Variable<Secret, COM> for AuthorizationContext<C, COM>
 where
     COM: Has<bool, Type = C::Bool>,

--- a/manta-accounting/src/wallet/mod.rs
+++ b/manta-accounting/src/wallet/mod.rs
@@ -344,7 +344,9 @@ where
                     InconsistencyError::SignerSynchronization,
                 ))
             }
-            Err(SyncError::MissingKey) => Err(Error::MissingPAKey),
+            Err(SyncError::MissingProofAuthorizationKey) => {
+                Err(Error::MissingProofAuthorizationKey)
+            }
         }
     }
 
@@ -583,7 +585,7 @@ where
     MissingSpendingKey,
 
     /// Missing Proof Authorization Key Error
-    MissingPAKey,
+    MissingProofAuthorizationKey,
 }
 
 impl<C, L, S> From<InconsistencyError> for Error<C, L, S>

--- a/manta-accounting/src/wallet/mod.rs
+++ b/manta-accounting/src/wallet/mod.rs
@@ -54,9 +54,9 @@ pub mod balance;
 pub mod ledger;
 pub mod signer;
 
-// #[cfg(feature = "test")]
-// #[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
-// pub mod test;
+#[cfg(feature = "test")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
+pub mod test;
 
 /// Wallet
 #[cfg_attr(

--- a/manta-accounting/src/wallet/mod.rs
+++ b/manta-accounting/src/wallet/mod.rs
@@ -54,9 +54,9 @@ pub mod balance;
 pub mod ledger;
 pub mod signer;
 
-#[cfg(feature = "test")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
-pub mod test;
+// #[cfg(feature = "test")]
+// #[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
+// pub mod test;
 
 /// Wallet
 #[cfg_attr(
@@ -344,6 +344,7 @@ where
                     InconsistencyError::SignerSynchronization,
                 ))
             }
+            Err(SyncError::MissingKey) => Err(Error::MissingPAKey),
         }
     }
 
@@ -454,7 +455,7 @@ where
 
     /// Returns the address.
     #[inline]
-    pub async fn address(&mut self) -> Result<Address<C>, S::Error> {
+    pub async fn address(&mut self) -> Result<Option<Address<C>>, S::Error> {
         self.signer.address().await
     }
 
@@ -577,6 +578,12 @@ where
 
     /// Ledger Connection Error
     LedgerConnectionError(L::Error),
+
+    /// Missing Spending Key Error
+    MissingSpendingKey,
+
+    /// Missing Proof Authorization Key Error
+    MissingPAKey,
 }
 
 impl<C, L, S> From<InconsistencyError> for Error<C, L, S>

--- a/manta-accounting/src/wallet/signer/mod.rs
+++ b/manta-accounting/src/wallet/signer/mod.rs
@@ -1295,6 +1295,20 @@ where
         self.assets = signer.state.assets.clone();
     }
 
+    /// Builds a new [`StorageState`] from `signer`.
+    #[inline]
+    pub fn from_signer(signer: &Signer<C>) -> Self
+    where
+        C::UtxoAccumulator: Clone,
+        C::AssetMap: Clone,
+    {
+        Self {
+            checkpoint: signer.state.checkpoint.clone(),
+            utxo_accumulator: signer.state.utxo_accumulator.clone(),
+            assets: signer.state.assets.clone(),
+        }
+    }
+
     /// Updates `signer` from `self`.
     #[inline]
     pub fn update_signer(&self, signer: &mut Signer<C>)

--- a/manta-accounting/src/wallet/signer/mod.rs
+++ b/manta-accounting/src/wallet/signer/mod.rs
@@ -416,7 +416,7 @@ where
     },
 
     /// Missing Proof Authorization Key
-    MissingKey,
+    MissingProofAuthorizationKey,
 }
 
 /// Synchronization Result
@@ -596,7 +596,7 @@ where
     ProofSystemError(ProofSystemError<C>),
 
     /// Missing Spending Key
-    MissingKey,
+    MissingSpendingKey,
 }
 
 /// Signing Result
@@ -1060,7 +1060,7 @@ where
             self.state
                 .authorization_context
                 .as_mut()
-                .ok_or(SyncError::MissingKey)?,
+                .ok_or(SyncError::MissingProofAuthorizationKey)?,
             &mut self.state.assets,
             &mut self.state.checkpoint,
             &mut self.state.utxo_accumulator,
@@ -1090,7 +1090,10 @@ where
     pub fn sign(&mut self, transaction: Transaction<C>) -> Result<SignResponse<C>, SignError<C>> {
         functions::sign(
             &self.parameters,
-            self.state.accounts.as_ref().ok_or(SignError::MissingKey)?,
+            self.state
+                .accounts
+                .as_ref()
+                .ok_or(SignError::MissingSpendingKey)?,
             &self.state.assets,
             &mut self.state.utxo_accumulator,
             transaction,
@@ -1155,7 +1158,10 @@ where
     {
         functions::sign_with_transaction_data(
             &self.parameters,
-            self.state.accounts.as_ref().ok_or(SignError::MissingKey)?,
+            self.state
+                .accounts
+                .as_ref()
+                .ok_or(SignError::MissingSpendingKey)?,
             &self.state.assets,
             &mut self.state.utxo_accumulator,
             transaction,

--- a/manta-accounting/src/wallet/test/mod.rs
+++ b/manta-accounting/src/wallet/test/mod.rs
@@ -460,7 +460,8 @@ where
         self.wallet
             .address()
             .await
-            .map_err(Error::SignerConnectionError)
+            .map_err(Error::SignerConnectionError)?
+            .ok_or(Error::MissingSpendingKey)
     }
 
     /// Returns the latest public balances from the ledger.
@@ -500,7 +501,7 @@ where
 
     /// Returns the [`Address`].
     #[inline]
-    pub async fn address(&mut self) -> Result<Address<C>, S::Error> {
+    pub async fn address(&mut self) -> Result<Option<Address<C>>, S::Error> {
         self.wallet.address().await
     }
 
@@ -1009,7 +1010,8 @@ impl Config {
                 .wallet
                 .address()
                 .await
-                .expect("Wallet should have address");
+                .expect("Wallet should have address")
+                .expect("Missing spending key");
             simulation.addresses.lock().insert(address);
         }
         let mut simulator = sim::Simulator::new(sim::ActionSim(simulation), actors);

--- a/manta-pay/src/config/mod.rs
+++ b/manta-pay/src/config/mod.rs
@@ -125,6 +125,9 @@ pub type UtxoAccumulatorOutput = transfer::UtxoAccumulatorOutput<Config>;
 pub type UtxoAccumulatorModel = transfer::UtxoAccumulatorModel<Config>;
 
 /// Full Transfer Parameters
+pub type FullParameters = transfer::FullParameters<'static, Config>;
+
+/// Full Transfer Parameters
 pub type FullParametersRef<'p> = transfer::FullParametersRef<'p, Config>;
 
 /// Authorization Context Type

--- a/manta-pay/src/lib.rs
+++ b/manta-pay/src/lib.rs
@@ -41,13 +41,13 @@ pub mod parameters;
 #[cfg_attr(doc_cfg, doc(cfg(feature = "groth16")))]
 pub mod signer;
 
-#[cfg(all(feature = "groth16", feature = "simulation"))]
-#[cfg_attr(doc_cfg, doc(cfg(all(feature = "groth16", feature = "simulation"))))]
-pub mod simulation;
+// #[cfg(all(feature = "groth16", feature = "simulation"))]
+// #[cfg_attr(doc_cfg, doc(cfg(all(feature = "groth16", feature = "simulation"))))]
+// pub mod simulation;
 
-#[cfg(any(test, feature = "test"))]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
-pub mod test;
+// #[cfg(any(test, feature = "test"))]
+// #[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
+// pub mod test;
 
 #[doc(inline)]
 pub use manta_accounting;

--- a/manta-pay/src/lib.rs
+++ b/manta-pay/src/lib.rs
@@ -41,13 +41,13 @@ pub mod parameters;
 #[cfg_attr(doc_cfg, doc(cfg(feature = "groth16")))]
 pub mod signer;
 
-// #[cfg(all(feature = "groth16", feature = "simulation"))]
-// #[cfg_attr(doc_cfg, doc(cfg(all(feature = "groth16", feature = "simulation"))))]
-// pub mod simulation;
+#[cfg(all(feature = "groth16", feature = "simulation"))]
+#[cfg_attr(doc_cfg, doc(cfg(all(feature = "groth16", feature = "simulation"))))]
+pub mod simulation;
 
-// #[cfg(any(test, feature = "test"))]
-// #[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
-// pub mod test;
+#[cfg(any(test, feature = "test"))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
+pub mod test;
 
 #[doc(inline)]
 pub use manta_accounting;

--- a/manta-pay/src/signer/client/http.rs
+++ b/manta-pay/src/signer/client/http.rs
@@ -100,7 +100,7 @@ impl signer::Connection<Config> for Client {
     }
 
     #[inline]
-    fn address(&mut self) -> LocalBoxFutureResult<Address, Self::Error> {
+    fn address(&mut self) -> LocalBoxFutureResult<Option<Address>, Self::Error> {
         Box::pin(async move {
             self.base
                 .post("address", &self.wrap_request(GetRequest::Get))

--- a/manta-pay/src/signer/client/websocket.rs
+++ b/manta-pay/src/signer/client/websocket.rs
@@ -149,7 +149,7 @@ impl signer::Connection<Config> for Client {
     }
 
     #[inline]
-    fn address(&mut self) -> LocalBoxFutureResult<Address, Self::Error> {
+    fn address(&mut self) -> LocalBoxFutureResult<Option<Address>, Self::Error> {
         Box::pin(async move { self.send("address", GetRequest::Get).await })
     }
 

--- a/manta-pay/src/signer/functions.rs
+++ b/manta-pay/src/signer/functions.rs
@@ -18,8 +18,8 @@
 
 use crate::{
     config::{
-        Address, AuthorizationContext, Config, EmbeddedScalar, IdentifiedAsset, IdentityProof,
-        MultiProvingContext, Parameters, Transaction, TransactionData, TransferPost,
+        Address, AuthorizationContext, Config, EmbeddedScalar, FullParameters, IdentifiedAsset,
+        IdentityProof, MultiProvingContext, Parameters, Transaction, TransactionData, TransferPost,
         UtxoAccumulatorModel,
     },
     key::{KeySecret, Mnemonic},
@@ -36,12 +36,15 @@ use manta_crypto::{accumulator::Accumulator, rand::FromEntropy};
 /// loading its state from `storage_state`, if possible.
 #[inline]
 pub fn new_signer(
-    parameters: Parameters,
+    parameters: FullParameters,
     proving_context: MultiProvingContext,
-    utxo_accumulator_model: &UtxoAccumulatorModel,
     storage_state: &StorageStateOption,
 ) -> Signer {
-    let mut signer = new_signer_from_model(parameters, proving_context, utxo_accumulator_model);
+    let mut signer = new_signer_from_model(
+        parameters.base,
+        proving_context,
+        &parameters.utxo_accumulator_model,
+    );
     if let Some(state) = storage_state {
         state.update_signer(&mut signer);
     }

--- a/manta-pay/src/signer/functions.rs
+++ b/manta-pay/src/signer/functions.rs
@@ -70,7 +70,7 @@ fn new_signer_from_accumulator(
 /// which is a time-consuming operation. One should favor the `new_signer` and
 /// `initialize_signer_from_storage` functions when possible.
 #[inline]
-fn new_signer_from_model(
+pub fn new_signer_from_model(
     parameters: Parameters,
     proving_context: MultiProvingContext,
     utxo_accumulator_model: &UtxoAccumulatorModel,

--- a/manta-pay/src/signer/functions.rs
+++ b/manta-pay/src/signer/functions.rs
@@ -24,10 +24,11 @@ use crate::{
     key::{KeySecret, Mnemonic},
     signer::{
         base::{Signer, SignerParameters, UtxoAccumulator},
-        AccountTable, AssetMap, Checkpoint, SignResult, SignerRng, SyncRequest, SyncResult,
+        AccountTable, AssetMap, Checkpoint, SignResult, SignerRng, StorageStateOption, SyncRequest,
+        SyncResult,
     },
 };
-use manta_accounting::wallet::signer::{functions, StorageState};
+use manta_accounting::wallet::signer::functions;
 use manta_crypto::{accumulator::Accumulator, rand::FromEntropy};
 
 /// Builds a new [`Signer`] from `parameters` and `proving_context`,
@@ -37,7 +38,7 @@ pub fn new_signer(
     parameters: Parameters,
     proving_context: MultiProvingContext,
     utxo_accumulator_model: &UtxoAccumulatorModel,
-    storage_state: &Option<StorageState<Config>>,
+    storage_state: &StorageStateOption,
 ) -> Signer {
     let mut signer = new_signer_from_model(parameters, proving_context, utxo_accumulator_model);
     if let Some(state) = storage_state {

--- a/manta-pay/src/signer/functions.rs
+++ b/manta-pay/src/signer/functions.rs
@@ -83,20 +83,22 @@ pub fn new_signer_from_model(
     )
 }
 
-/// Loads the [`AccountTable`] from `mnemonic` to `signer`.
+/// Creates an [`AccountTable`] from `mnemonic`.
 #[inline]
-pub fn load_accounts(signer: &mut Signer, mnemonic: Mnemonic) {
-    signer.load_accounts(AccountTable::new(KeySecret::new(mnemonic, "")))
+pub fn accounts_from_mnemonic(mnemonic: Mnemonic) -> AccountTable {
+    AccountTable::new(KeySecret::new(mnemonic, ""))
 }
 
-/// Loads the [`AuthorizationContext`] from `mnemonic` to `signer`.
+/// Creates an [`AuthorizationContext`] from `mnemonic` and `parameters`.
 #[inline]
-pub fn load_authorization_context(signer: &mut Signer, mnemonic: Mnemonic) {
-    let authorization_context = functions::default_authorization_context::<Config>(
+pub fn authorization_context_from_mnemonic(
+    mnemonic: Mnemonic,
+    parameters: &Parameters,
+) -> AuthorizationContext {
+    functions::default_authorization_context::<Config>(
         &AccountTable::new(KeySecret::new(mnemonic, "")),
-        &signer.parameters().parameters,
-    );
-    signer.load_authorization_context(authorization_context)
+        parameters,
+    )
 }
 
 /// Updates `assets`, `checkpoint` and `utxo_accumulator`, returning the new asset distribution.

--- a/manta-pay/src/signer/functions.rs
+++ b/manta-pay/src/signer/functions.rs
@@ -25,8 +25,8 @@ use crate::{
     key::{KeySecret, Mnemonic},
     signer::{
         base::{Signer, SignerParameters, UtxoAccumulator},
-        AccountTable, AssetMap, Checkpoint, SignResult, SignerRng, StorageStateOption, SyncRequest,
-        SyncResult,
+        AccountTable, AssetMap, Checkpoint, SignResult, SignerRng, StorageState,
+        StorageStateOption, SyncRequest, SyncResult,
     },
 };
 use manta_accounting::{key::DeriveAddress, wallet::signer::functions};
@@ -49,6 +49,22 @@ pub fn new_signer(
         state.update_signer(&mut signer);
     }
     signer
+}
+
+/// Builds a new [`StorageStateOption`] from `signer`.
+#[inline]
+pub fn set_storage(signer: &Signer) -> StorageStateOption {
+    Some(StorageState::from_signer(signer))
+}
+
+/// Tries to update `signer` from `storage_state`.
+#[inline]
+pub fn get_storage(signer: &mut Signer, storage_state: &StorageStateOption) -> bool {
+    if let Some(storage_state) = storage_state {
+        storage_state.update_signer(signer);
+        return true;
+    }
+    false
 }
 
 /// Builds a new [`Signer`] `parameters`, `proving_context` and `utxo_accumulator`.

--- a/manta-pay/src/signer/functions.rs
+++ b/manta-pay/src/signer/functions.rs
@@ -18,8 +18,9 @@
 
 use crate::{
     config::{
-        Address, AuthorizationContext, Config, IdentifiedAsset, IdentityProof, MultiProvingContext,
-        Parameters, Transaction, TransactionData, TransferPost, UtxoAccumulatorModel,
+        Address, AuthorizationContext, Config, EmbeddedScalar, IdentifiedAsset, IdentityProof,
+        MultiProvingContext, Parameters, Transaction, TransactionData, TransferPost,
+        UtxoAccumulatorModel,
     },
     key::{KeySecret, Mnemonic},
     signer::{
@@ -28,7 +29,7 @@ use crate::{
         SyncResult,
     },
 };
-use manta_accounting::wallet::signer::functions;
+use manta_accounting::{key::DeriveAddress, wallet::signer::functions};
 use manta_crypto::{accumulator::Accumulator, rand::FromEntropy};
 
 /// Builds a new [`Signer`] from `parameters` and `proving_context`,
@@ -99,6 +100,21 @@ pub fn authorization_context_from_mnemonic(
         &AccountTable::new(KeySecret::new(mnemonic, "")),
         parameters,
     )
+}
+
+/// Creates a viewing key from `mnemonic`.
+#[inline]
+pub fn viewing_key_from_mnemonic(mnemonic: Mnemonic, parameters: &Parameters) -> EmbeddedScalar {
+    *authorization_context_from_mnemonic(mnemonic, parameters)
+        .viewing_key(&parameters.base.viewing_key_derivation_function, &mut ())
+}
+
+/// Creates an [`Address`] from `mnemonic`.
+#[inline]
+pub fn address_from_mnemonic(mnemonic: Mnemonic, parameters: &Parameters) -> Address {
+    accounts_from_mnemonic(mnemonic)
+        .get_default()
+        .address(parameters)
 }
 
 /// Updates `assets`, `checkpoint` and `utxo_accumulator`, returning the new asset distribution.

--- a/manta-pay/src/signer/mod.rs
+++ b/manta-pay/src/signer/mod.rs
@@ -27,7 +27,7 @@ use manta_accounting::wallet::signer;
 #[cfg(feature = "serde")]
 use manta_util::serde::{Deserialize, Serialize};
 
-//pub mod client;
+pub mod client;
 
 #[cfg(feature = "wallet")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "wallet")))]

--- a/manta-pay/src/signer/mod.rs
+++ b/manta-pay/src/signer/mod.rs
@@ -27,7 +27,7 @@ use manta_accounting::wallet::signer;
 #[cfg(feature = "serde")]
 use manta_util::serde::{Deserialize, Serialize};
 
-pub mod client;
+//pub mod client;
 
 #[cfg(feature = "wallet")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "wallet")))]

--- a/manta-pay/src/signer/mod.rs
+++ b/manta-pay/src/signer/mod.rs
@@ -88,8 +88,11 @@ pub type SignWithTransactionDataResult = signer::SignWithTransactionDataResult<C
 /// Sign With Transaction Data Response
 pub type SignWithTransactionDataResponse = signer::SignWithTransactionDataResponse<Config>;
 
+/// Storage State
+pub type StorageState = signer::StorageState<Config>;
+
 /// Storage State Option
-pub type StorageStateOption = Option<signer::StorageState<Config>>;
+pub type StorageStateOption = Option<StorageState>;
 
 /// Receiving Key Request
 #[cfg_attr(

--- a/manta-pay/src/signer/mod.rs
+++ b/manta-pay/src/signer/mod.rs
@@ -88,6 +88,9 @@ pub type SignWithTransactionDataResult = signer::SignWithTransactionDataResult<C
 /// Sign With Transaction Data Response
 pub type SignWithTransactionDataResponse = signer::SignWithTransactionDataResponse<Config>;
 
+/// Storage State Option
+pub type StorageStateOption = Option<signer::StorageState<Config>>;
+
 /// Receiving Key Request
 #[cfg_attr(
     feature = "serde",

--- a/manta-pay/src/test/signer.rs
+++ b/manta-pay/src/test/signer.rs
@@ -47,7 +47,7 @@ fn identity_proof_test() {
     let identity_proof = signer
         .identity_proof(virtual_asset)
         .expect("Error producing identity proof");
-    let address = signer.address();
+    let address = signer.address().expect("Sampled signer has a spending key");
     assert!(
         identity_verification(
             &identity_proof,
@@ -132,9 +132,11 @@ fn transaction_data_test() {
         .take_first();
     let utxo = response.0.body.receiver_posts.take_first().utxo;
     assert!(
-        response
-            .1
-            .check_transaction_data(&parameters, &signer.address(), &vec![utxo]),
+        response.1.check_transaction_data(
+            &parameters,
+            &signer.address().expect("Sampled signer has a spending key"),
+            &vec![utxo]
+        ),
         "Invalid Transaction Data"
     );
 }

--- a/manta-pay/src/test/signer.rs
+++ b/manta-pay/src/test/signer.rs
@@ -18,12 +18,17 @@
 
 use crate::{
     config::{Asset, Config},
+    key::Mnemonic,
     parameters::load_parameters,
-    signer::base::identity_verification,
+    signer::{
+        base::identity_verification,
+        functions::{address_from_mnemonic, authorization_context_from_mnemonic},
+    },
     simulation::sample_signer,
 };
 use manta_accounting::transfer::{canonical::Transaction, IdentifiedAsset, Identifier};
 use manta_crypto::{
+    algebra::HasGenerator,
     arkworks::constraint::fp::Fp,
     rand::{fuzz::Fuzz, OsRng, Rand},
 };
@@ -138,5 +143,27 @@ fn transaction_data_test() {
             &vec![utxo]
         ),
         "Invalid Transaction Data"
+    );
+}
+
+/// Checks that both methods to derive a receiving key from a [`Mnemonic`] give
+/// the same result.
+#[test]
+pub fn derive_address_works() {
+    let mut rng = OsRng;
+    let directory = tempfile::tempdir().expect("Unable to generate temporary test directory.");
+    let (_, _, parameters, _) =
+        load_parameters(directory.path()).expect("Failed to load parameters");
+    let mnemonic = Mnemonic::sample(&mut rng);
+    let receiving_key_1 = address_from_mnemonic(mnemonic.clone(), &parameters).receiving_key;
+    let receiving_key_2 = *authorization_context_from_mnemonic(mnemonic, &parameters)
+        .receiving_key(
+            parameters.base.group_generator.generator(),
+            &parameters.base.viewing_key_derivation_function,
+            &mut (),
+        );
+    assert_eq!(
+        receiving_key_1, receiving_key_2,
+        "Both receiving keys should be the same"
     );
 }


### PR DESCRIPTION
Goes together with https://github.com/Manta-Network/sdk/pull/85

Changes for `Signer` and `SignerState` in `manta-accounting::wallet::signer`:
- `SignerState`, instead of an `AccountTable` to be initialized, now it has `Option<AccountTable>` and `Option<AuthorizationContext>`.
- `sign` requires `AccountTable` to be there. New field in `SignError` if it's `None`.
- `sync` requires `AuthorizationContext` to be there. New field in `SyncError` if it's `None`.
- New methods: instantiation without `AccountTable`, and loading/dropping `AccountTable` and `AuthorizationContext`.

More changes with design decisions: 
- `address` requires `AccountTable`. We could require the weaker `AuthorizationContext` for this, or, have an `Address` field in `SignerState` because it is the lowest level of security.
- `address` now returns `Option<Address>` because of this.
- `transaction_data` requires `AccountTable`. We could require the weaker `AuthorizationContext` for this or, have a `DecryptionKey` field in `SignerState` because that's all it's needed. However, it makes sense to require the `AccountTable` because it's commonly used in the compound method `sign_with_transaction_data`, which does require `AccountTable`.
- `transaction_data` and `identity_proof` still return `Option`. Perhaps it makes sense that they return more verbose `Result`s now?

`manta-pay::signer::functions.rs` changes: 
- Function `new_signer` initializes the signer with just parameters and optionally the state.
- Derivation of all keys from a `Mnemonic`.

---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-rs/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
- [x] Checked that changes and commits conform to the standards outlined in [`CONTRIBUTING.md`](https://github.com/manta-network/manta-rs/blob/main/CONTRIBUTING.md).
