### PR TITLE
Security: Include the sink AccountId in the signed message for ToPublic transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 ### Security
+-[\#324](https://github.com/Manta-Network/manta-rs/pull/324) Include the sink AccountId in the signed message for ToPublic transactions.
 
 ## [0.5.11] - 2023-02-22
 ### Added

--- a/manta-accounting/src/transfer/mod.rs
+++ b/manta-accounting/src/transfer/mod.rs
@@ -69,9 +69,9 @@ pub mod receiver;
 pub mod sender;
 pub mod utxo;
 
-// #[cfg(feature = "test")]
-// #[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
-// pub mod test;
+#[cfg(feature = "test")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
+pub mod test;
 
 #[doc(inline)]
 pub use canonical::Shape;

--- a/manta-accounting/src/transfer/mod.rs
+++ b/manta-accounting/src/transfer/mod.rs
@@ -1686,8 +1686,8 @@ impl<C> TransferPost<C>
 where
     C: Configuration + ?Sized,
 {
-    /// Builds a new [`TransferPost`] without checking the consistency conditions between the `body`
-    /// and the `authorization_signature`.
+    /// Builds a new [`TransferPost`] without checking the consistency conditions between the `body`,
+    /// the `authorization_signature` and the `sink_accounts`.
     #[inline]
     fn new_unchecked_with_sinks(
         authorization_signature: Option<AuthorizationSignature<C>>,

--- a/manta-accounting/src/transfer/mod.rs
+++ b/manta-accounting/src/transfer/mod.rs
@@ -69,9 +69,9 @@ pub mod receiver;
 pub mod sender;
 pub mod utxo;
 
-#[cfg(feature = "test")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
-pub mod test;
+// #[cfg(feature = "test")]
+// #[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
+// pub mod test;
 
 #[doc(inline)]
 pub use canonical::Shape;
@@ -94,6 +94,12 @@ pub const fn requires_authorization(senders: usize) -> bool {
     senders > 0
 }
 
+/// Returns `true` if the [`Transfer`] with this shape has sinks.
+#[inline]
+pub const fn has_sinks(sinks: usize) -> bool {
+    sinks > 0
+}
+
 /// Configuration
 pub trait Configuration {
     /// Compiler Type
@@ -104,6 +110,9 @@ pub trait Configuration {
 
     /// Asset Value Type
     type AssetValue: AddAssign + Clone + Default + PartialOrd + Sum;
+
+    /// Account Identifier
+    type AccountId: Clone;
 
     /// Associated Data Type
     type AssociatedData: Default;
@@ -143,8 +152,8 @@ pub trait Configuration {
         + auth::ProveAuthorization
         + auth::VerifyAuthorization
         + auth::DeriveSigningKey
-        + auth::Sign<TransferPostBody<Self>>
-        + auth::VerifySignature<TransferPostBody<Self>>
+        + for<'a> auth::Sign<BodyWithAccountsRef<'a, Self>>
+        + for<'a> auth::VerifySignature<BodyWithAccountsRef<'a, Self>>
         + utxo::AssetType<Asset = Asset<Self>>
         + utxo::AssociatedDataType<AssociatedData = Self::AssociatedData>
         + utxo::DeriveMint<
@@ -730,6 +739,7 @@ where
         parameters: FullParametersRef<C>,
         proving_context: &ProvingContext<C>,
         spending_key: Option<&SpendingKey<C>>,
+        sink_accounts: Vec<C::AccountId>,
         rng: &mut R,
     ) -> Result<Option<TransferPost<C>>, ProofSystemError<C>>
     where
@@ -743,17 +753,28 @@ where
             (true, true, Some(spending_key)) => {
                 let (body, authorization) =
                     self.into_post_body_with_authorization(parameters, proving_context, rng)?;
+                let body_with_accounts = BodyWithAccountsRef::new(&body, &sink_accounts);
                 match auth::sign(
                     parameters.base,
                     spending_key,
                     authorization.expect("It is known to be `Some` from the check above."),
-                    &body,
+                    &body_with_accounts,
                     rng,
                 ) {
-                    Some(authorization_signature) => Ok(Some(TransferPost::new_unchecked(
-                        Some(authorization_signature),
-                        body,
-                    ))),
+                    Some(authorization_signature) => {
+                        if has_sinks(SINKS) {
+                            Ok(Some(TransferPost::new_unchecked_with_sinks(
+                                Some(authorization_signature),
+                                body,
+                                sink_accounts,
+                            )))
+                        } else {
+                            Ok(Some(TransferPost::new_unchecked(
+                                Some(authorization_signature),
+                                body,
+                            )))
+                        }
+                    }
                     _ => Ok(None),
                 }
             }
@@ -1044,9 +1065,6 @@ where
     /// Type that allows super-traits of [`TransferLedger`] to customize posting key behavior.
     type SuperPostingKey: Copy;
 
-    /// Account Identifier
-    type AccountId;
-
     /// Ledger Event
     type Event;
 
@@ -1083,7 +1101,7 @@ where
         + Into<
             TransferPostError<
                 C,
-                Self::AccountId,
+                C::AccountId,
                 <Self as SenderLedger<Parameters<C>>>::Error,
                 <Self as ReceiverLedger<Parameters<C>>>::Error,
                 <Self as TransferLedger<C>>::Error,
@@ -1096,18 +1114,18 @@ where
         &self,
         asset_id: &C::AssetId,
         sources: I,
-    ) -> Result<Vec<Self::ValidSourceAccount>, InvalidSourceAccount<C, Self::AccountId>>
+    ) -> Result<Vec<Self::ValidSourceAccount>, InvalidSourceAccount<C, C::AccountId>>
     where
-        I: Iterator<Item = (Self::AccountId, C::AssetValue)>;
+        I: Iterator<Item = (C::AccountId, C::AssetValue)>;
 
     /// Checks that the sink accounts exist and balance can be increased by the specified amounts.
     fn check_sink_accounts<I>(
         &self,
         asset_id: &C::AssetId,
         sinks: I,
-    ) -> Result<Vec<Self::ValidSinkAccount>, InvalidSinkAccount<C, Self::AccountId>>
+    ) -> Result<Vec<Self::ValidSinkAccount>, InvalidSinkAccount<C, C::AccountId>>
     where
-        I: Iterator<Item = (Self::AccountId, C::AssetValue)>;
+        I: Iterator<Item = (C::AccountId, C::AssetValue)>;
 
     /// Checks that the transfer proof stored in `posting_key` is valid.
     fn is_valid(
@@ -1232,7 +1250,7 @@ where
 /// Transfer Ledger Post Error
 pub type TransferLedgerPostError<C, L> = TransferPostError<
     C,
-    <L as TransferLedger<C>>::AccountId,
+    <C as Configuration>::AccountId,
     <L as SenderLedger<Parameters<C>>>::Error,
     <L as ReceiverLedger<Parameters<C>>>::Error,
     <L as TransferLedger<C>>::Error,
@@ -1572,6 +1590,49 @@ where
     }
 }
 
+/// Body With Accounts Reference
+pub struct BodyWithAccountsRef<'p, C>
+where
+    C: Configuration + ?Sized,
+{
+    /// Transfer Post Body
+    pub body: &'p TransferPostBody<C>,
+
+    /// Sink Accounts
+    pub sink_accounts: &'p Vec<C::AccountId>,
+}
+
+impl<'p, C> BodyWithAccountsRef<'p, C>
+where
+    C: Configuration + ?Sized,
+{
+    ///
+    #[inline]
+    pub fn new(body: &'p TransferPostBody<C>, sink_accounts: &'p Vec<C::AccountId>) -> Self {
+        Self {
+            body,
+            sink_accounts,
+        }
+    }
+}
+
+impl<'p, C> Encode for BodyWithAccountsRef<'p, C>
+where
+    C: Configuration + ?Sized,
+    TransferPostBody<C>: Encode,
+    C::AccountId: Encode,
+{
+    #[inline]
+    fn encode<W>(&self, mut writer: W) -> Result<(), W::Error>
+    where
+        W: Write,
+    {
+        self.body.encode(&mut writer)?;
+        self.sink_accounts.encode(&mut writer)?;
+        Ok(())
+    }
+}
+
 /// Transfer Post
 #[cfg_attr(
     feature = "serde",
@@ -1581,10 +1642,12 @@ where
             deserialize = r"
                 AuthorizationSignature<C>: Deserialize<'de>,
                 TransferPostBody<C>: Deserialize<'de>,
+                C::AccountId: Deserialize<'de>,
             ",
             serialize = r"
                 AuthorizationSignature<C>: Serialize,
                 TransferPostBody<C>: Serialize,
+                C::AccountId: Serialize
             ",
         ),
         crate = "manta_util::serde",
@@ -1593,11 +1656,17 @@ where
 )]
 #[derive(derivative::Derivative)]
 #[derivative(
-    Clone(bound = "AuthorizationSignature<C>: Clone, TransferPostBody<C>: Clone"),
-    Debug(bound = "AuthorizationSignature<C>: Debug, TransferPostBody<C>: Debug"),
-    Eq(bound = "AuthorizationSignature<C>: Eq, TransferPostBody<C>: Eq"),
-    Hash(bound = "AuthorizationSignature<C>: Hash, TransferPostBody<C>: Hash"),
-    PartialEq(bound = "AuthorizationSignature<C>: PartialEq, TransferPostBody<C>: PartialEq")
+    Clone(
+        bound = "AuthorizationSignature<C>: Clone, TransferPostBody<C>: Clone, C::AccountId: Clone"
+    ),
+    Debug(
+        bound = "AuthorizationSignature<C>: Debug, TransferPostBody<C>: Debug, C::AccountId: Debug"
+    ),
+    Eq(bound = "AuthorizationSignature<C>: Eq, TransferPostBody<C>: Eq, C::AccountId: Eq"),
+    Hash(bound = "AuthorizationSignature<C>: Hash, TransferPostBody<C>: Hash, C::AccountId: Hash"),
+    PartialEq(
+        bound = "AuthorizationSignature<C>: PartialEq, TransferPostBody<C>: PartialEq, C::AccountId: PartialEq"
+    )
 )]
 pub struct TransferPost<C>
 where
@@ -1608,6 +1677,9 @@ where
 
     /// Transfer Post Body
     pub body: TransferPostBody<C>,
+
+    /// Sink Accounts
+    pub sink_accounts: Vec<C::AccountId>,
 }
 
 impl<C> TransferPost<C>
@@ -1617,14 +1689,26 @@ where
     /// Builds a new [`TransferPost`] without checking the consistency conditions between the `body`
     /// and the `authorization_signature`.
     #[inline]
-    fn new_unchecked(
+    fn new_unchecked_with_sinks(
         authorization_signature: Option<AuthorizationSignature<C>>,
         body: TransferPostBody<C>,
+        sink_accounts: Vec<C::AccountId>,
     ) -> Self {
         Self {
             authorization_signature,
             body,
+            sink_accounts,
         }
+    }
+
+    /// Builds a new [`TransferPost`] without checking the consistency conditions between the `body`
+    /// and the `authorization_signature`.
+    #[inline]
+    fn new_unchecked(
+        authorization_signature: Option<AuthorizationSignature<C>>,
+        body: TransferPostBody<C>,
+    ) -> Self {
+        Self::new_unchecked_with_sinks(authorization_signature, body, Vec::new())
     }
 
     /// Returns the `k`-th source in the transfer.
@@ -1687,7 +1771,8 @@ where
             requires_authorization(self.body.sender_posts.len()),
         ) {
             (Some(authorization_signature), true) => {
-                if authorization_signature.verify(parameters, &self.body) {
+                let body_with_accounts = BodyWithAccountsRef::new(&self.body, &self.sink_accounts);
+                if authorization_signature.verify(parameters, &body_with_accounts) {
                     Ok(())
                 } else {
                     Err(InvalidAuthorizationSignature::BadSignature)
@@ -1705,9 +1790,9 @@ where
     #[inline]
     fn check_public_participants<L>(
         asset_id: &Option<C::AssetId>,
-        source_accounts: Vec<L::AccountId>,
+        source_accounts: Vec<C::AccountId>,
         source_values: Vec<C::AssetValue>,
-        sink_accounts: Vec<L::AccountId>,
+        sink_accounts: Vec<C::AccountId>,
         sink_values: Vec<C::AssetValue>,
         ledger: &L,
     ) -> Result<(Vec<L::ValidSourceAccount>, Vec<L::ValidSinkAccount>), TransferLedgerPostError<C, L>>
@@ -1751,8 +1836,8 @@ where
         self,
         parameters: &C::Parameters,
         ledger: &L,
-        source_accounts: Vec<L::AccountId>,
-        sink_accounts: Vec<L::AccountId>,
+        source_accounts: Vec<C::AccountId>,
+        sink_accounts: Vec<C::AccountId>,
     ) -> Result<TransferPostingKey<C, L>, TransferLedgerPostError<C, L>>
     where
         L: TransferLedger<C>,
@@ -1816,8 +1901,8 @@ where
         parameters: &C::Parameters,
         ledger: &mut L,
         super_key: &TransferLedgerSuperPostingKey<C, L>,
-        source_accounts: Vec<L::AccountId>,
-        sink_accounts: Vec<L::AccountId>,
+        source_accounts: Vec<C::AccountId>,
+        sink_accounts: Vec<C::AccountId>,
     ) -> Result<L::Event, TransferLedgerPostError<C, L>>
     where
         L: TransferLedger<C>,

--- a/manta-accounting/src/transfer/mod.rs
+++ b/manta-accounting/src/transfer/mod.rs
@@ -1606,7 +1606,7 @@ impl<'p, C> BodyWithAccountsRef<'p, C>
 where
     C: Configuration + ?Sized,
 {
-    ///
+    /// Builds a new [`BodyWithAccountsRef`] from `body` and `sink_accounts`.
     #[inline]
     pub fn new(body: &'p TransferPostBody<C>, sink_accounts: &'p Vec<C::AccountId>) -> Self {
         Self {

--- a/manta-accounting/src/transfer/test.rs
+++ b/manta-accounting/src/transfer/test.rs
@@ -518,7 +518,7 @@ where
     );
     Ok((
         transaction
-            .into_post(parameters, proving_context, None, rng)?
+            .into_post(parameters, proving_context, None, Vec::new(), rng)?
             .expect("The `ToPrivate` transaction does not require authorization."),
         pre_sender,
     ))

--- a/manta-accounting/src/transfer/test.rs
+++ b/manta-accounting/src/transfer/test.rs
@@ -231,14 +231,17 @@ where
     where
         A: Accumulator<Item = UtxoAccumulatorItem<C>, Model = UtxoAccumulatorModel<C>>,
         for<'s> Self: Sample<TransferDistribution<'s, C, A>>,
+        C::AccountId: Sample,
         R: CryptoRng + RngCore + ?Sized,
     {
         let (spending_key, distribution) =
             Self::generate_distribution(parameters, utxo_accumulator, spending_key, rng);
+        let sink_accounts: [C::AccountId; SINKS] = rng.gen();
         Self::sample(distribution, rng).into_post(
             FullParametersRef::<C>::new(parameters, utxo_accumulator.model()),
             proving_context,
             spending_key,
+            sink_accounts.to_vec(),
             rng,
         )
     }
@@ -256,6 +259,7 @@ where
     where
         A: Accumulator<Item = UtxoAccumulatorItem<C>, Model = UtxoAccumulatorModel<C>>,
         for<'s> Self: Sample<TransferDistribution<'s, C, A>>,
+        C::AccountId: Sample,
         R: CryptoRng + RngCore + ?Sized,
     {
         let (proving_context, verifying_context) = Self::generate_context(
@@ -287,6 +291,7 @@ where
     where
         A: Accumulator<Item = UtxoAccumulatorItem<C>, Model = UtxoAccumulatorModel<C>>,
         for<'s> Self: Sample<TransferDistribution<'s, C, A>>,
+        C::AccountId: Sample,
         R: CryptoRng + RngCore + ?Sized,
     {
         Self::sample_post(
@@ -324,7 +329,13 @@ where
         let (proving_context, _) = Self::generate_context(public_parameters, full_parameters, rng)?;
         Ok(transfer.generate_proof_input()
             == transfer
-                .into_post(full_parameters, &proving_context, spending_key, rng)?
+                .into_post(
+                    full_parameters,
+                    &proving_context,
+                    spending_key,
+                    Default::default(),
+                    rng,
+                )?
                 .expect("TransferPost should have been constructed correctly.")
                 .generate_proof_input())
     }

--- a/manta-accounting/src/wallet/mod.rs
+++ b/manta-accounting/src/wallet/mod.rs
@@ -54,9 +54,9 @@ pub mod balance;
 pub mod ledger;
 pub mod signer;
 
-// #[cfg(feature = "test")]
-// #[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
-// pub mod test;
+#[cfg(feature = "test")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
+pub mod test;
 
 /// Wallet
 #[cfg_attr(

--- a/manta-accounting/src/wallet/mod.rs
+++ b/manta-accounting/src/wallet/mod.rs
@@ -54,9 +54,9 @@ pub mod balance;
 pub mod ledger;
 pub mod signer;
 
-#[cfg(feature = "test")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
-pub mod test;
+// #[cfg(feature = "test")]
+// #[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
+// pub mod test;
 
 /// Wallet
 #[cfg_attr(
@@ -407,13 +407,13 @@ where
     #[inline]
     pub async fn identity_proof(
         &mut self,
-        virtual_assets: Vec<IdentifiedAsset<C>>,
+        request: Vec<(IdentifiedAsset<C>, C::AccountId)>,
     ) -> Result<IdentityResponse<C>, Error<C, L, S>>
     where
         UtxoAccumulatorModel<C>: Clone,
     {
         self.signer
-            .identity_proof(IdentityRequest(virtual_assets))
+            .identity_proof(IdentityRequest(request))
             .await
             .map_err(Error::SignerConnectionError)
     }

--- a/manta-accounting/src/wallet/signer/functions.rs
+++ b/manta-accounting/src/wallet/signer/functions.rs
@@ -735,7 +735,6 @@ fn sign_internal<C>(
     assets: &C::AssetMap,
     utxo_accumulator: &mut C::UtxoAccumulator,
     transaction: Transaction<C>,
-    sink_accounts: Vec<C::AccountId>,
     rng: &mut C::Rng,
 ) -> Result<SignResponse<C>, SignError<C>>
 where
@@ -762,17 +761,17 @@ where
             utxo_accumulator,
             asset,
             Some(address),
-            sink_accounts,
+            Vec::new(),
             rng,
         ),
-        Transaction::ToPublic(asset) => sign_withdraw(
+        Transaction::ToPublic(asset, public_account) => sign_withdraw(
             parameters,
             accounts,
             assets,
             utxo_accumulator,
             asset,
             None,
-            sink_accounts,
+            Vec::from([public_account]),
             rng,
         ),
     }
@@ -786,7 +785,6 @@ pub fn sign<C>(
     assets: &C::AssetMap,
     utxo_accumulator: &mut C::UtxoAccumulator,
     transaction: Transaction<C>,
-    sink_accounts: Vec<C::AccountId>,
     rng: &mut C::Rng,
 ) -> Result<SignResponse<C>, SignError<C>>
 where
@@ -798,7 +796,6 @@ where
         assets,
         utxo_accumulator,
         transaction,
-        sink_accounts,
         rng,
     )?;
     utxo_accumulator.rollback();
@@ -813,7 +810,7 @@ pub fn identity_proof<C>(
     accounts: &AccountTable<C>,
     utxo_accumulator_model: &UtxoAccumulatorModel<C>,
     identified_asset: IdentifiedAsset<C>,
-    sink_accounts: Vec<C::AccountId>,
+    public_account: C::AccountId,
     rng: &mut C::Rng,
 ) -> Option<IdentityProof<C>>
 where
@@ -849,7 +846,7 @@ where
         &parameters.parameters,
         &parameters.proving_context.to_public,
         ToPublic::build(authorization, senders, [change], identified_asset.asset),
-        sink_accounts,
+        Vec::from([public_account]),
         rng,
     )
     .ok()?;
@@ -912,7 +909,6 @@ pub fn sign_with_transaction_data<C>(
     assets: &C::AssetMap,
     utxo_accumulator: &mut C::UtxoAccumulator,
     transaction: Transaction<C>,
-    sink_accounts: Vec<C::AccountId>,
     rng: &mut C::Rng,
 ) -> SignWithTransactionDataResult<C>
 where
@@ -926,7 +922,6 @@ where
             assets,
             utxo_accumulator,
             transaction,
-            sink_accounts,
             rng,
         )?
         .posts

--- a/manta-benchmark/benches/to_public.rs
+++ b/manta-benchmark/benches/to_public.rs
@@ -17,7 +17,7 @@
 //! To Public Benchmarks
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use manta_crypto::rand::OsRng;
+use manta_crypto::rand::{OsRng, Rand};
 use manta_pay::{
     parameters,
     test::payment::{to_public::prove as prove_to_public, UtxoAccumulator},
@@ -27,12 +27,14 @@ fn prove(c: &mut Criterion) {
     let mut group = c.benchmark_group("bench");
     let mut rng = OsRng;
     let (proving_context, _, parameters, utxo_accumulator_model) = parameters::generate().unwrap();
+    let public_account = rng.gen();
     group.bench_function("to public prove", |b| {
         b.iter(|| {
             prove_to_public(
                 &proving_context.to_public,
                 &parameters,
                 &mut UtxoAccumulator::new(utxo_accumulator_model.clone()),
+                public_account,
                 &mut rng,
             );
         })
@@ -44,10 +46,12 @@ fn verify(c: &mut Criterion) {
     let mut rng = OsRng;
     let (proving_context, verifying_context, parameters, utxo_accumulator_model) =
         parameters::generate().unwrap();
+    let public_account = rng.gen();
     let transferpost = black_box(prove_to_public(
         &proving_context.to_public,
         &parameters,
         &mut UtxoAccumulator::new(utxo_accumulator_model.clone()),
+        public_account,
         &mut rng,
     ));
     group.bench_function("to public verify", |b| {

--- a/manta-benchmark/src/transfer.rs
+++ b/manta-benchmark/src/transfer.rs
@@ -113,6 +113,7 @@ pub fn prove_to_public(context: &Context) -> TransferPost {
             &mut UtxoAccumulator::new(context.utxo_accumulator_model.clone()),
             rng.gen(),
             [rng.gen::<_, u128>() / 2, rng.gen::<_, u128>() / 2],
+            rng.gen(),
             &mut rng,
         )
         .1,

--- a/manta-crypto/src/rand.rs
+++ b/manta-crypto/src/rand.rs
@@ -585,6 +585,8 @@ pub mod fuzz {
         result
     }
 
+    #[cfg(feature = "rand")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "rand")))]
     impl Fuzz for u8 {
         #[inline]
         fn fuzz<R>(&self, rng: &mut R) -> Self

--- a/manta-pay/Cargo.toml
+++ b/manta-pay/Cargo.toml
@@ -113,7 +113,7 @@ bip0039 = { version = "0.10.1", optional = true, default-features = false }
 bip32 = { version = "0.3.0", optional = true, default-features = false, features = ["bip39", "secp256k1"] }
 blake2 = { version = "0.10.6", default-features = false }
 bs58 = { version = "0.4.0", optional = true, default-features = false, features = ["alloc"] }
-clap = { version = "3.2.23", optional = true, default-features = false, features = ["color", "derive", "std", "suggestions", "unicode", "wrap_help"] }
+clap = { version = "4.1.8", optional = true, default-features = false, features = ["color", "derive", "std", "suggestions", "unicode", "wrap_help"] }
 derivative = { version = "2.2.0", default-features = false, features = ["use_core"] }
 futures = { version = "0.3.25", optional = true, default-features = false }
 indexmap = { version = "1.9.2", optional = true, default-features = false }

--- a/manta-pay/src/config/mod.rs
+++ b/manta-pay/src/config/mod.rs
@@ -78,6 +78,9 @@ pub type ProofSystem = groth16::Groth16<PairingCurve>;
 /// Proof System Error
 pub type ProofSystemError = groth16::Error;
 
+/// Account Identifier
+pub type AccountId = [u8; 32];
+
 /// Transfer Configuration
 #[derive(derivative::Derivative)]
 #[derivative(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
@@ -87,6 +90,7 @@ impl transfer::Configuration for Config {
     type Compiler = Compiler;
     type AssetId = utxo::AssetId;
     type AssetValue = utxo::AssetValue;
+    type AccountId = AccountId;
     type AssociatedData = utxo::AssociatedData;
     type Utxo = utxo::Utxo;
     type Nullifier = utxo::Nullifier;

--- a/manta-pay/src/lib.rs
+++ b/manta-pay/src/lib.rs
@@ -41,9 +41,9 @@ pub mod parameters;
 #[cfg_attr(doc_cfg, doc(cfg(feature = "groth16")))]
 pub mod signer;
 
-// #[cfg(all(feature = "groth16", feature = "simulation"))]
-// #[cfg_attr(doc_cfg, doc(cfg(all(feature = "groth16", feature = "simulation"))))]
-// pub mod simulation;
+#[cfg(all(feature = "groth16", feature = "simulation"))]
+#[cfg_attr(doc_cfg, doc(cfg(all(feature = "groth16", feature = "simulation"))))]
+pub mod simulation;
 
 #[cfg(any(test, feature = "test"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]

--- a/manta-pay/src/lib.rs
+++ b/manta-pay/src/lib.rs
@@ -41,13 +41,13 @@ pub mod parameters;
 #[cfg_attr(doc_cfg, doc(cfg(feature = "groth16")))]
 pub mod signer;
 
-#[cfg(all(feature = "groth16", feature = "simulation"))]
-#[cfg_attr(doc_cfg, doc(cfg(all(feature = "groth16", feature = "simulation"))))]
-pub mod simulation;
+// #[cfg(all(feature = "groth16", feature = "simulation"))]
+// #[cfg_attr(doc_cfg, doc(cfg(all(feature = "groth16", feature = "simulation"))))]
+// pub mod simulation;
 
-#[cfg(any(test, feature = "test"))]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
-pub mod test;
+// #[cfg(any(test, feature = "test"))]
+// #[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
+// pub mod test;
 
 #[doc(inline)]
 pub use manta_accounting;

--- a/manta-pay/src/lib.rs
+++ b/manta-pay/src/lib.rs
@@ -45,9 +45,9 @@ pub mod signer;
 // #[cfg_attr(doc_cfg, doc(cfg(all(feature = "groth16", feature = "simulation"))))]
 // pub mod simulation;
 
-// #[cfg(any(test, feature = "test"))]
-// #[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
-// pub mod test;
+#[cfg(any(test, feature = "test"))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
+pub mod test;
 
 #[doc(inline)]
 pub use manta_accounting;

--- a/manta-pay/src/lib.rs
+++ b/manta-pay/src/lib.rs
@@ -41,13 +41,13 @@ pub mod parameters;
 #[cfg_attr(doc_cfg, doc(cfg(feature = "groth16")))]
 pub mod signer;
 
-// #[cfg(all(feature = "groth16", feature = "simulation"))]
-// #[cfg_attr(doc_cfg, doc(cfg(all(feature = "groth16", feature = "simulation"))))]
-// pub mod simulation;
+#[cfg(all(feature = "groth16", feature = "simulation"))]
+#[cfg_attr(doc_cfg, doc(cfg(all(feature = "groth16", feature = "simulation"))))]
+pub mod simulation;
 
-// #[cfg(any(test, feature = "test"))]
-// #[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
-// pub mod test;
+#[cfg(any(test, feature = "test"))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
+pub mod test;
 
 #[doc(inline)]
 pub use manta_accounting;

--- a/manta-pay/src/signer/base.rs
+++ b/manta-pay/src/signer/base.rs
@@ -19,8 +19,8 @@
 use crate::{
     config::{
         utxo::{self, MerkleTreeConfiguration},
-        Address, Config, IdentifiedAsset, IdentityProof, Parameters, UtxoAccumulatorModel,
-        VerifyingContext,
+        AccountId, Address, Config, IdentifiedAsset, IdentityProof, Parameters,
+        UtxoAccumulatorModel, VerifyingContext,
     },
     key::{CoinType, KeySecret, Testnet},
     signer::{AssetMetadata, Checkpoint},
@@ -214,6 +214,7 @@ pub fn identity_verification(
     utxo_accumulator_model: &UtxoAccumulatorModel,
     virtual_asset: IdentifiedAsset,
     address: Address,
+    public_account: AccountId,
 ) -> Result<(), IdentityVerificationError> {
     if virtual_asset.identifier.is_transparent || virtual_asset.asset.id.0.is_zero() {
         return Err(IdentityVerificationError::InvalidVirtualAsset);
@@ -224,5 +225,6 @@ pub fn identity_verification(
         utxo_accumulator_model,
         virtual_asset,
         address,
+        public_account,
     )
 }

--- a/manta-pay/src/signer/functions.rs
+++ b/manta-pay/src/signer/functions.rs
@@ -39,13 +39,11 @@ pub fn new_signer(
     parameters: FullParameters,
     proving_context: MultiProvingContext,
     storage_state: &StorageStateOption,
-    public_account: AccountId,
 ) -> Signer {
     let mut signer = new_signer_from_model(
         parameters.base,
         proving_context,
         &parameters.utxo_accumulator_model,
-        public_account,
     );
     if let Some(state) = storage_state {
         state.update_signer(&mut signer);
@@ -75,13 +73,11 @@ fn new_signer_from_accumulator(
     parameters: Parameters,
     proving_context: MultiProvingContext,
     utxo_accumulator: UtxoAccumulator,
-    public_account: AccountId,
 ) -> Signer {
     Signer::new(
         parameters,
         proving_context,
         utxo_accumulator,
-        public_account,
         FromEntropy::from_entropy(),
     )
 }
@@ -99,13 +95,11 @@ pub fn new_signer_from_model(
     parameters: Parameters,
     proving_context: MultiProvingContext,
     utxo_accumulator_model: &UtxoAccumulatorModel,
-    public_account: AccountId,
 ) -> Signer {
     new_signer_from_accumulator(
         parameters,
         proving_context,
         Accumulator::empty(utxo_accumulator_model),
-        public_account,
     )
 }
 
@@ -173,7 +167,6 @@ pub fn sign(
     assets: &AssetMap,
     utxo_accumulator: &mut UtxoAccumulator,
     transaction: Transaction,
-    public_account: AccountId,
     rng: &mut SignerRng,
 ) -> SignResult {
     functions::sign(
@@ -182,7 +175,6 @@ pub fn sign(
         assets,
         utxo_accumulator,
         transaction,
-        Vec::from([public_account]),
         rng,
     )
 }
@@ -220,7 +212,7 @@ pub fn identity_proof(
         accounts,
         utxo_accumulator_model,
         identified_asset,
-        Vec::from([public_account]),
+        public_account,
         rng,
     )
 }

--- a/manta-pay/src/signer/functions.rs
+++ b/manta-pay/src/signer/functions.rs
@@ -18,9 +18,9 @@
 
 use crate::{
     config::{
-        Address, AuthorizationContext, Config, EmbeddedScalar, FullParameters, IdentifiedAsset,
-        IdentityProof, MultiProvingContext, Parameters, Transaction, TransactionData, TransferPost,
-        UtxoAccumulatorModel,
+        AccountId, Address, AuthorizationContext, Config, EmbeddedScalar, FullParameters,
+        IdentifiedAsset, IdentityProof, MultiProvingContext, Parameters, Transaction,
+        TransactionData, TransferPost, UtxoAccumulatorModel,
     },
     key::{KeySecret, Mnemonic},
     signer::{
@@ -39,11 +39,13 @@ pub fn new_signer(
     parameters: FullParameters,
     proving_context: MultiProvingContext,
     storage_state: &StorageStateOption,
+    public_account: AccountId,
 ) -> Signer {
     let mut signer = new_signer_from_model(
         parameters.base,
         proving_context,
         &parameters.utxo_accumulator_model,
+        public_account,
     );
     if let Some(state) = storage_state {
         state.update_signer(&mut signer);
@@ -73,11 +75,13 @@ fn new_signer_from_accumulator(
     parameters: Parameters,
     proving_context: MultiProvingContext,
     utxo_accumulator: UtxoAccumulator,
+    public_account: AccountId,
 ) -> Signer {
     Signer::new(
         parameters,
         proving_context,
         utxo_accumulator,
+        public_account,
         FromEntropy::from_entropy(),
     )
 }
@@ -95,11 +99,13 @@ pub fn new_signer_from_model(
     parameters: Parameters,
     proving_context: MultiProvingContext,
     utxo_accumulator_model: &UtxoAccumulatorModel,
+    public_account: AccountId,
 ) -> Signer {
     new_signer_from_accumulator(
         parameters,
         proving_context,
         Accumulator::empty(utxo_accumulator_model),
+        public_account,
     )
 }
 
@@ -167,6 +173,7 @@ pub fn sign(
     assets: &AssetMap,
     utxo_accumulator: &mut UtxoAccumulator,
     transaction: Transaction,
+    public_account: AccountId,
     rng: &mut SignerRng,
 ) -> SignResult {
     functions::sign(
@@ -175,6 +182,7 @@ pub fn sign(
         assets,
         utxo_accumulator,
         transaction,
+        Vec::from([public_account]),
         rng,
     )
 }
@@ -204,6 +212,7 @@ pub fn identity_proof(
     accounts: &AccountTable,
     utxo_accumulator_model: &UtxoAccumulatorModel,
     identified_asset: IdentifiedAsset,
+    public_account: AccountId,
     rng: &mut SignerRng,
 ) -> Option<IdentityProof> {
     functions::identity_proof(
@@ -211,6 +220,7 @@ pub fn identity_proof(
         accounts,
         utxo_accumulator_model,
         identified_asset,
+        Vec::from([public_account]),
         rng,
     )
 }

--- a/manta-pay/src/simulation/ledger/mod.rs
+++ b/manta-pay/src/simulation/ledger/mod.rs
@@ -23,7 +23,7 @@ use crate::config::{
     utxo::{
         AssetId, AssetValue, Checkpoint, FullIncomingNote, MerkleTreeConfiguration, Parameters,
     },
-    Config, MultiVerifyingContext, Nullifier, ProofSystem, TransferPost, Utxo,
+    AccountId, Config, MultiVerifyingContext, Nullifier, ProofSystem, TransferPost, Utxo,
     UtxoAccumulatorModel,
 };
 use alloc::{sync::Arc, vec::Vec};
@@ -105,15 +105,6 @@ impl<L, R> AsRef<R> for WrapPair<L, R> {
         &self.1
     }
 }
-
-/// Account Id
-#[cfg_attr(
-    feature = "serde",
-    derive(Deserialize, Serialize),
-    serde(crate = "manta_util::serde", deny_unknown_fields, transparent)
-)]
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct AccountId(pub u64);
 
 /// Ledger
 #[derive(Debug)]
@@ -459,10 +450,9 @@ impl ReceiverLedger<Parameters> for Ledger {
 }
 
 impl TransferLedger<Config> for Ledger {
-    type AccountId = AccountId;
     type Event = ();
-    type ValidSourceAccount = WrapPair<Self::AccountId, AssetValue>;
-    type ValidSinkAccount = WrapPair<Self::AccountId, AssetValue>;
+    type ValidSourceAccount = WrapPair<AccountId, AssetValue>;
+    type ValidSinkAccount = WrapPair<AccountId, AssetValue>;
     type ValidProof = Wrap<()>;
     type SuperPostingKey = ();
     type Error = TransferLedgerError;
@@ -472,9 +462,9 @@ impl TransferLedger<Config> for Ledger {
         &self,
         asset_id: &AssetId,
         sources: I,
-    ) -> Result<Vec<Self::ValidSourceAccount>, InvalidSourceAccount<Config, Self::AccountId>>
+    ) -> Result<Vec<Self::ValidSourceAccount>, InvalidSourceAccount<Config, AccountId>>
     where
-        I: Iterator<Item = (Self::AccountId, AssetValue)>,
+        I: Iterator<Item = (AccountId, AssetValue)>,
     {
         sources
             .map(|(account_id, withdraw)| {
@@ -515,9 +505,9 @@ impl TransferLedger<Config> for Ledger {
         &self,
         asset_id: &AssetId,
         sinks: I,
-    ) -> Result<Vec<Self::ValidSinkAccount>, InvalidSinkAccount<Config, Self::AccountId>>
+    ) -> Result<Vec<Self::ValidSinkAccount>, InvalidSinkAccount<Config, AccountId>>
     where
-        I: Iterator<Item = (Self::AccountId, AssetValue)>,
+        I: Iterator<Item = (AccountId, AssetValue)>,
     {
         sinks
             .map(move |(account_id, deposit)| {

--- a/manta-pay/src/test/compatibility.rs
+++ b/manta-pay/src/test/compatibility.rs
@@ -26,7 +26,7 @@ use crate::{
         to_public::prove as prove_to_public,
     },
 };
-use manta_crypto::rand::OsRng;
+use manta_crypto::rand::{OsRng, Rand};
 
 /// Tests that the circuit is compatible with the current known parameters in `manta-parameters`.
 #[test]
@@ -54,6 +54,7 @@ fn compatibility() {
         &proving_context.to_public,
         &parameters,
         &mut utxo_accumulator,
+        rng.gen(),
         &mut rng,
     )
     .assert_valid_proof(&verifying_context.to_public);

--- a/manta-pay/src/test/mod.rs
+++ b/manta-pay/src/test/mod.rs
@@ -16,11 +16,11 @@
 
 //! Manta Pay Testing
 
-#[cfg(test)]
-pub mod balance;
+// #[cfg(test)]
+// pub mod balance;
 
-#[cfg(test)]
-pub mod compatibility;
+// #[cfg(test)]
+// pub mod compatibility;
 
 #[cfg(test)]
 pub mod transfer;
@@ -29,7 +29,7 @@ pub mod transfer;
 #[cfg_attr(doc_cfg, doc(cfg(feature = "groth16")))]
 pub mod payment;
 
-#[cfg(all(feature = "groth16", feature = "simulation"))]
-#[cfg_attr(doc_cfg, doc(cfg(all(feature = "groth16", feature = "simulation"))))]
-#[cfg(test)]
-pub mod signer;
+// #[cfg(all(feature = "groth16", feature = "simulation"))]
+// #[cfg_attr(doc_cfg, doc(cfg(all(feature = "groth16", feature = "simulation"))))]
+// #[cfg(test)]
+// pub mod signer;

--- a/manta-pay/src/test/mod.rs
+++ b/manta-pay/src/test/mod.rs
@@ -16,11 +16,11 @@
 
 //! Manta Pay Testing
 
-// #[cfg(test)]
-// pub mod balance;
+#[cfg(test)]
+pub mod balance;
 
-// #[cfg(test)]
-// pub mod compatibility;
+#[cfg(test)]
+pub mod compatibility;
 
 #[cfg(test)]
 pub mod transfer;
@@ -29,7 +29,7 @@ pub mod transfer;
 #[cfg_attr(doc_cfg, doc(cfg(feature = "groth16")))]
 pub mod payment;
 
-// #[cfg(all(feature = "groth16", feature = "simulation"))]
-// #[cfg_attr(doc_cfg, doc(cfg(all(feature = "groth16", feature = "simulation"))))]
-// #[cfg(test)]
-// pub mod signer;
+#[cfg(all(feature = "groth16", feature = "simulation"))]
+#[cfg_attr(doc_cfg, doc(cfg(all(feature = "groth16", feature = "simulation"))))]
+#[cfg(test)]
+pub mod signer;

--- a/manta-pay/src/test/payment.rs
+++ b/manta-pay/src/test/payment.rs
@@ -18,9 +18,11 @@
 
 use crate::config::{
     utxo::{MerkleTreeConfiguration, UtxoAccumulatorItem, UtxoAccumulatorModel},
-    Asset, AssetId, AssetValue, Authorization, Config, FullParametersRef, MultiProvingContext,
-    Parameters, PrivateTransfer, ProvingContext, Receiver, ToPrivate, ToPublic, TransferPost,
+    AccountId, Asset, AssetId, AssetValue, Authorization, Config, FullParametersRef,
+    MultiProvingContext, Parameters, PrivateTransfer, ProvingContext, Receiver, ToPrivate,
+    ToPublic, TransferPost,
 };
+use alloc::vec::Vec;
 use manta_accounting::transfer::{self, internal_pair, test::value_distribution};
 use manta_crypto::{
     accumulator::Accumulator,
@@ -67,6 +69,7 @@ pub mod to_private {
                 FullParametersRef::new(parameters, utxo_accumulator_model),
                 proving_context,
                 None,
+                Vec::new(),
                 rng,
             )
             .expect("Unable to build TO_PRIVATE proof.")
@@ -108,6 +111,7 @@ pub mod to_private {
                 FullParametersRef::new(parameters, utxo_accumulator.model()),
                 proving_context,
                 None,
+                Vec::new(),
                 rng,
             )
             .expect("Unable to build TO_PRIVATE proof.")
@@ -153,6 +157,7 @@ pub mod private_transfer {
                 FullParametersRef::new(parameters, utxo_accumulator.model()),
                 &proving_context.to_private,
                 None,
+                Vec::new(),
                 rng,
             )
             .expect("Unable to build TO_PRIVATE proof.")
@@ -175,6 +180,7 @@ pub mod private_transfer {
                 FullParametersRef::new(parameters, utxo_accumulator.model()),
                 &proving_context.to_private,
                 None,
+                Vec::new(),
                 rng,
             )
             .expect("Unable to build TO_PRIVATE proof.")
@@ -196,6 +202,7 @@ pub mod private_transfer {
             FullParametersRef::new(parameters, utxo_accumulator.model()),
             &proving_context.private_transfer,
             Some(&spending_key),
+            Vec::new(),
             rng,
         )
         .expect("Unable to build PRIVATE_TRANSFER proof.")
@@ -252,6 +259,7 @@ pub mod private_transfer {
             FullParametersRef::new(parameters, utxo_accumulator.model()),
             proving_context,
             Some(&spending_key),
+            Vec::new(),
             rng,
         )
         .expect("Unable to build PRIVATE_TRANSFER proof.")
@@ -272,6 +280,7 @@ pub mod to_public {
         utxo_accumulator: &mut A,
         asset_id: AssetId,
         values: [AssetValue; 2],
+        public_account: AccountId,
         rng: &mut R,
     ) -> ([TransferPost; 2], TransferPost)
     where
@@ -297,6 +306,7 @@ pub mod to_public {
                 FullParametersRef::new(parameters, utxo_accumulator.model()),
                 &proving_context.to_private,
                 None,
+                Vec::new(),
                 rng,
             )
             .expect("Unable to build TO_PRIVATE proof.")
@@ -318,6 +328,7 @@ pub mod to_public {
                 FullParametersRef::new(parameters, utxo_accumulator.model()),
                 &proving_context.to_private,
                 None,
+                Vec::new(),
                 rng,
             )
             .expect("Unable to build TO_PRIVATE proof.")
@@ -333,6 +344,7 @@ pub mod to_public {
                 FullParametersRef::new(parameters, utxo_accumulator.model()),
                 &proving_context.to_public,
                 Some(&spending_key),
+                Vec::from([public_account]),
                 rng,
             )
             .expect("Unable to build TO_PUBLIC proof.")
@@ -347,6 +359,7 @@ pub mod to_public {
         proving_context: &ProvingContext,
         parameters: &Parameters,
         utxo_accumulator: &mut A,
+        public_account: AccountId,
         rng: &mut R,
     ) -> TransferPost
     where
@@ -386,6 +399,7 @@ pub mod to_public {
                 FullParametersRef::new(parameters, utxo_accumulator.model()),
                 proving_context,
                 Some(&spending_key),
+                Vec::from([public_account]),
                 rng,
             )
             .expect("Unable to build TO_PUBLIC proof.")

--- a/manta-pay/src/test/signer.rs
+++ b/manta-pay/src/test/signer.rs
@@ -61,7 +61,8 @@ fn identity_proof_test() {
             &verifying_context.to_public,
             &utxo_accumulator_model,
             virtual_asset,
-            address
+            address,
+            public_account
         )
         .is_ok(),
         "Verification failed"
@@ -76,7 +77,8 @@ fn identity_proof_test() {
                 Identifier::<Config>::new(true, identifier.utxo_commitment_randomness),
                 virtual_asset.asset,
             ),
-            address
+            address,
+            public_account
         )
         .is_err(),
         "Verification should have failed"
@@ -94,7 +96,8 @@ fn identity_proof_test() {
                 ),
                 virtual_asset.asset,
             ),
-            address
+            address,
+            public_account
         )
         .is_err(),
         "Verification should have failed"
@@ -109,7 +112,8 @@ fn identity_proof_test() {
                 virtual_asset.identifier,
                 Asset::new(virtual_asset.asset.id, rng.gen()),
             ),
-            address
+            address,
+            public_account
         )
         .is_err(),
         "Verification should have failed"

--- a/manta-pay/src/test/signer.rs
+++ b/manta-pay/src/test/signer.rs
@@ -49,8 +49,9 @@ fn identity_proof_test() {
     );
     let identifier = Identifier::<Config>::new(false, rng.gen());
     let virtual_asset = IdentifiedAsset::<Config>::new(identifier, rng.gen());
+    let public_account = rng.gen();
     let identity_proof = signer
-        .identity_proof(virtual_asset)
+        .identity_proof(virtual_asset, public_account)
         .expect("Error producing identity proof");
     let address = signer.address().expect("Sampled signer has a spending key");
     assert!(

--- a/manta-pay/src/test/transfer.rs
+++ b/manta-pay/src/test/transfer.rs
@@ -17,14 +17,17 @@
 //! Manta Pay Transfer Testing
 
 use crate::{
-    config::{FullParametersRef, Parameters, PrivateTransfer, ProofSystem, ToPrivate, ToPublic},
+    config::{
+        FullParametersRef, Parameters, PrivateTransfer, ProofSystem, ToPrivate, ToPublic,
+        TransferPost,
+    },
     test::payment::UtxoAccumulator,
 };
-use manta_accounting::transfer::test::validity_check_with_fuzzing;
+use manta_accounting::transfer::{test::validity_check_with_fuzzing, BodyWithAccountsRef};
 use manta_crypto::{
     accumulator::Accumulator,
     constraint::{measure::Measure, ProofSystem as _},
-    rand::{OsRng, Rand, Sample},
+    rand::{fuzz::Fuzz, OsRng, Rand, Sample},
 };
 
 /// Tests the generation of proving/verifying contexts for [`ToPrivate`].
@@ -178,14 +181,35 @@ fn to_public_check_signature() {
     .expect("Random To-Public should have produced a proof.")
     .expect("");
     post.assert_valid_proof(&verifying_context);
+    let body_with_accounts = BodyWithAccountsRef::new(&post.body, &post.sink_accounts);
     assert!(
         manta_accounting::transfer::utxo::auth::test::signature_correctness(
             &parameters,
             &spending_key,
-            &post.body,
+            &body_with_accounts,
             &mut rng,
         ),
         "Invalid signature."
+    );
+    assert!(
+        post.has_valid_authorization_signature(&parameters).is_ok(),
+        "Invalid signature."
+    );
+    let fuzzed_account = vec![post.sink_accounts[0]
+        .to_vec()
+        .fuzz(&mut rng)
+        .try_into()
+        .expect("Getting an array from a vector of equal length is not allowed to fail")];
+    let new_post = TransferPost {
+        authorization_signature: post.authorization_signature.clone(),
+        body: post.body.clone(),
+        sink_accounts: fuzzed_account,
+    };
+    assert!(
+        new_post
+            .has_valid_authorization_signature(&parameters)
+            .is_err(),
+        "Valid signature should have been invalid."
     );
 }
 

--- a/manta-pay/src/test/transfer.rs
+++ b/manta-pay/src/test/transfer.rs
@@ -201,7 +201,7 @@ fn to_public_check_signature() {
         .try_into()
         .expect("Getting an array from a vector of equal length is not allowed to fail")];
     let new_post = TransferPost {
-        authorization_signature: post.authorization_signature.clone(),
+        authorization_signature: post.authorization_signature,
         body: post.body.clone(),
         sink_accounts: fuzzed_account,
     };

--- a/manta-trusted-setup/Cargo.toml
+++ b/manta-trusted-setup/Cargo.toml
@@ -106,7 +106,7 @@ bincode = { version = "1.3.3", optional = true, default-features = false }
 blake2 = { version = "0.10.6", default-features = false }
 bs58 = { version = "0.4.0", optional = true, default-features = false, features = ["alloc"] }
 chrono = { version = "0.4.19", optional = true, default-features = false, features = ["clock"] }
-clap = { version = "3.2.23", optional = true, default-features = false, features = ["color", "derive", "std", "suggestions", "unicode", "wrap_help"] }
+clap = { version = "4.1.8", optional = true, default-features = false, features = ["color", "derive", "std", "suggestions", "unicode", "wrap_help"] }
 colored = { version = "2.0.0", optional = true, default-features = false }
 console = { version = "0.15.4", optional = true, default-features = false }
 csv = { version = "1.1.6", optional = true, default-features = false }


### PR DESCRIPTION
Due to the bug where an attacker could perform a replay attack on someone's valid ToPublic post by changing the public `AccountId`, we needed to sign this last field together with the `TransferPostBody`.

Main changes: 
-`auth::sign` and `auth::verify` now take `BodyWithAccountsRef` instead of `TransferPostBody`.
- transfer: 
1) `AccountId` is now an associated type of the `Configuration` trait, instead of the `Ledger` one.
2)  The `Transaction` enum in the `ToPublic` case now includes an `AccountId`.
3) `TransferPost` includes a `sink_accounts` field.
4) `IdentityVerification::verify` now verifies against a `public_account` as well.
- signer:
1) The function `identity_proof` also takes (a vector of) `C::AccountId` as input.

Misc:
- updated the `clap` dependency so it passes the lint after the latest rustup update.
- more on the `identity_proof` clumsy function: https://github.com/Manta-Network/manta-rs/issues/325

Related PRs: 
- [x] Update the pallet: https://github.com/Manta-Network/Manta/pull/1032
- [x] Update the sdk: https://github.com/Manta-Network/sdk/pull/102
- [x] Signer: https://github.com/Manta-Network/manta-signer/pull/332 
---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-rs/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
- [x] Checked that changes and commits conform to the standards outlined in [`CONTRIBUTING.md`](https://github.com/manta-network/manta-rs/blob/main/CONTRIBUTING.md).
