### PR TITLE
Expose reset wallet method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Added
+- [\#328](https://github.com/Manta-Network/manta-rs/pull/328) Expose reset wallet method.
 
 ### Changed
 

--- a/manta-accounting/src/wallet/mod.rs
+++ b/manta-accounting/src/wallet/mod.rs
@@ -37,9 +37,9 @@ use crate::{
         balance::{BTreeMapBalanceState, BalanceState},
         ledger::ReadResponse,
         signer::{
-            BalanceUpdate, IdentityRequest, IdentityResponse, SignError, SignRequest,
-            SignResponse, SignWithTransactionDataResponse, SyncData, SyncError,
-            SyncRequest, SyncResponse, TransactionDataRequest, TransactionDataResponse,
+            BalanceUpdate, IdentityRequest, IdentityResponse, SignError, SignRequest, SignResponse,
+            SignWithTransactionDataResponse, SyncData, SyncError, SyncRequest, SyncResponse,
+            TransactionDataRequest, TransactionDataResponse,
         },
     },
 };

--- a/manta-accounting/src/wallet/mod.rs
+++ b/manta-accounting/src/wallet/mod.rs
@@ -37,8 +37,8 @@ use crate::{
         balance::{BTreeMapBalanceState, BalanceState},
         ledger::ReadResponse,
         signer::{
-            BalanceUpdate, IdentityRequest, IdentityResponse, LoadAndSave, SignError, SignRequest,
-            SignResponse, SignWithTransactionDataResponse, Storage, SyncData, SyncError,
+            BalanceUpdate, IdentityRequest, IdentityResponse, SignError, SignRequest,
+            SignResponse, SignWithTransactionDataResponse, SyncData, SyncError,
             SyncRequest, SyncResponse, TransactionDataRequest, TransactionDataResponse,
         },
     },
@@ -303,30 +303,6 @@ where
         })
         .await?;
         Ok(ControlFlow::should_continue(should_continue))
-    }
-
-    /// Pulls data from the ledger, synchronizing the wallet and balance state.
-    #[inline]
-    pub async fn sync_with_and_save(&mut self) -> Result<(ControlFlow, Storage<S>), Error<C, L, S>>
-    where
-        L: ledger::Read<SyncData<C>, Checkpoint = S::Checkpoint>,
-        S: LoadAndSave,
-    {
-        let ReadResponse {
-            should_continue,
-            data,
-        } = self
-            .ledger
-            .read(&self.checkpoint)
-            .await
-            .map_err(Error::LedgerConnectionError)?;
-        self.signer_sync(SyncRequest {
-            origin_checkpoint: self.checkpoint.clone(),
-            data,
-        })
-        .await?;
-        let storage = self.signer.set_storage();
-        Ok((ControlFlow::should_continue(should_continue), storage))
     }
 
     /// Performs a synchronization with the signer against the given `request`.

--- a/manta-accounting/src/wallet/signer/mod.rs
+++ b/manta-accounting/src/wallet/signer/mod.rs
@@ -108,21 +108,6 @@ where
         TransferPost<C>: Clone;
 }
 
-/// Signer State Loading and Saving
-pub trait LoadAndSave {
-    /// Storage Type
-    type Storage;
-
-    /// Saves `self` to storage.
-    fn set_storage(&self) -> Self::Storage;
-
-    /// Updates `self` from `storage`.
-    fn get_storage(&mut self, storage: &Self::Storage) -> bool;
-}
-
-/// Storage Type
-pub type Storage<L> = <L as LoadAndSave>::Storage;
-
 /// Signer Synchronization Data
 #[cfg_attr(
     feature = "serde",
@@ -1273,25 +1258,6 @@ where
         TransferPost<C>: Clone,
     {
         Box::pin(async move { Ok(self.sign_with_transaction_data(request.transaction)) })
-    }
-}
-
-impl<C> LoadAndSave for Signer<C>
-where
-    C: Configuration,
-    C::UtxoAccumulator: Clone,
-    C::AssetMap: Clone,
-{
-    type Storage = StorageStateOption<C>;
-
-    #[inline]
-    fn get_storage(&mut self, storage: &Self::Storage) -> bool {
-        self.get_storage(storage)
-    }
-
-    #[inline]
-    fn set_storage(&self) -> Self::Storage {
-        self.set_storage()
     }
 }
 

--- a/manta-accounting/src/wallet/signer/mod.rs
+++ b/manta-accounting/src/wallet/signer/mod.rs
@@ -1181,7 +1181,7 @@ where
 
     /// Builds a new [`StorageStateOption`] from `self`.
     #[inline]
-    pub fn set_storage(&self) -> StorageStateOption<C>
+    pub fn get_storage(&self) -> StorageStateOption<C>
     where
         C::UtxoAccumulator: Clone,
         C::AssetMap: Clone,
@@ -1191,7 +1191,7 @@ where
 
     /// Tries to update `self` from `storage_state`.
     #[inline]
-    pub fn get_storage(&mut self, storage_state: &StorageStateOption<C>) -> bool
+    pub fn set_storage(&mut self, storage_state: &StorageStateOption<C>) -> bool
     where
         C::UtxoAccumulator: Clone,
         C::AssetMap: Clone,

--- a/manta-pay/src/bin/simulation.rs
+++ b/manta-pay/src/bin/simulation.rs
@@ -31,17 +31,13 @@ pub fn main() {
         .worker_threads(6)
         .build()
     {
-        Ok(runtime) => runtime.block_on(async {
-            simulation
-                .run(
-                    &parameters,
-                    &utxo_accumulator_model,
-                    &proving_context,
-                    verifying_context,
-                    &mut rng,
-                )
-                .await
-        }),
+        Ok(runtime) => runtime.block_on(simulation.run(
+            &parameters,
+            &utxo_accumulator_model,
+            &proving_context,
+            verifying_context,
+            &mut rng,
+        )),
         Err(err) => Simulation::command()
             .error(
                 ErrorKind::Io,

--- a/manta-pay/src/signer/client/http.rs
+++ b/manta-pay/src/signer/client/http.rs
@@ -78,7 +78,7 @@ impl Client {
         }
     }
 
-    ///
+    /// Sends a POST of type `command` with query string `request`.
     #[inline]
     pub async fn post_request<T, R>(&self, command: &str, request: T) -> reqwest::Result<R>
     where

--- a/manta-pay/src/signer/client/websocket.rs
+++ b/manta-pay/src/signer/client/websocket.rs
@@ -137,7 +137,7 @@ impl signer::Connection<Config> for Client {
         &mut self,
         request: SyncRequest,
     ) -> LocalBoxFutureResult<Result<SyncResponse, SyncError>, Self::Error> {
-        Box::pin(async move { self.send("sync", request).await })
+        Box::pin(self.send("sync", request))
     }
 
     #[inline]
@@ -145,12 +145,12 @@ impl signer::Connection<Config> for Client {
         &mut self,
         request: SignRequest,
     ) -> LocalBoxFutureResult<Result<SignResponse, SignError>, Self::Error> {
-        Box::pin(async move { self.send("sign", request).await })
+        Box::pin(self.send("sign", request))
     }
 
     #[inline]
     fn address(&mut self) -> LocalBoxFutureResult<Option<Address>, Self::Error> {
-        Box::pin(async move { self.send("address", GetRequest::Get).await })
+        Box::pin(self.send("address", GetRequest::Get))
     }
 
     #[inline]
@@ -158,7 +158,7 @@ impl signer::Connection<Config> for Client {
         &mut self,
         request: TransactionDataRequest,
     ) -> LocalBoxFutureResult<TransactionDataResponse, Self::Error> {
-        Box::pin(async move { self.send("transaction_data", request).await })
+        Box::pin(self.send("transaction_data", request))
     }
 
     #[inline]
@@ -166,7 +166,7 @@ impl signer::Connection<Config> for Client {
         &mut self,
         request: IdentityRequest,
     ) -> LocalBoxFutureResult<IdentityResponse, Self::Error> {
-        Box::pin(async move { self.send("identity", request).await })
+        Box::pin(self.send("identity", request))
     }
 
     #[inline]
@@ -174,6 +174,6 @@ impl signer::Connection<Config> for Client {
         &mut self,
         request: SignRequest,
     ) -> LocalBoxFutureResult<SignWithTransactionDataResult, Self::Error> {
-        Box::pin(async move { self.send("sign_with_transaction_data", request).await })
+        Box::pin(self.send("sign_with_transaction_data", request))
     }
 }

--- a/manta-pay/src/signer/functions.rs
+++ b/manta-pay/src/signer/functions.rs
@@ -53,13 +53,13 @@ pub fn new_signer(
 
 /// Builds a new [`StorageStateOption`] from `signer`.
 #[inline]
-pub fn set_storage(signer: &Signer) -> StorageStateOption {
+pub fn get_storage(signer: &Signer) -> StorageStateOption {
     Some(StorageState::from_signer(signer))
 }
 
 /// Tries to update `signer` from `storage_state`.
 #[inline]
-pub fn get_storage(signer: &mut Signer, storage_state: &StorageStateOption) -> bool {
+pub fn set_storage(signer: &mut Signer, storage_state: &StorageStateOption) -> bool {
     if let Some(storage_state) = storage_state {
         storage_state.update_signer(signer);
         return true;

--- a/manta-pay/src/simulation/ledger/http/client.rs
+++ b/manta-pay/src/simulation/ledger/http/client.rs
@@ -59,7 +59,7 @@ impl Client {
         })
     }
 
-    ///
+    /// Sends a POST of type `command` with query string `request`.
     #[inline]
     pub async fn post_request<T, R>(&self, command: &str, request: T) -> reqwest::Result<R>
     where

--- a/manta-pay/src/simulation/ledger/http/server.rs
+++ b/manta-pay/src/simulation/ledger/http/server.rs
@@ -98,7 +98,7 @@ impl Server {
         Fut: Future<Output = R>,
     {
         let account = request.query::<AccountId>()?;
-        Self::into_body(move || async move { f(request.state().clone(), account).await }).await
+        Self::into_body(move || f(request.state().clone(), account)).await
     }
 
     /// Executes `f` on the incoming `request` parsing the full query.
@@ -114,10 +114,7 @@ impl Server {
         Fut: Future<Output = R>,
     {
         let args = request.query::<Request<T>>()?;
-        Self::into_body(move || async move {
-            f(request.state().clone(), args.account, args.request).await
-        })
-        .await
+        Self::into_body(move || f(request.state().clone(), args.account, args.request)).await
     }
 
     /// Generates the JSON body for the output of `f`, returning an HTTP reponse.

--- a/manta-trusted-setup/src/bin/groth16_phase2_client.rs
+++ b/manta-trusted-setup/src/bin/groth16_phase2_client.rs
@@ -94,8 +94,7 @@ impl Arguments {
                 {
                     Ok(runtime) => {
                         let pk = Array::from_unchecked(*pk.as_bytes());
-                        runtime
-                            .block_on(async { client_contribute::<Config>(sk, pk, self.url).await })
+                        runtime.block_on(client_contribute::<Config>(sk, pk, self.url))
                     }
                     Err(e) => panic!("I/O Error while setting up the tokio Runtime: {e:?}"),
                 }

--- a/manta-trusted-setup/src/groth16/ceremony/server.rs
+++ b/manta-trusted-setup/src/groth16/ceremony/server.rs
@@ -113,6 +113,7 @@ where
     }
 
     /// Recovers from disk files at `path` and uses `path` as the backup directory.
+    #[allow(clippy::redundant_async_block)] // Necessary to spawn a task with a server clone
     #[inline]
     pub fn recover(
         path: PathBuf,

--- a/manta-util/src/http/tide.rs
+++ b/manta-util/src/http/tide.rs
@@ -45,7 +45,7 @@ where
     Fut: Future<Output = Result<R, E>>,
 {
     let args = request.body_json::<T>().await?;
-    into_body(move || async move { f(request.state().clone(), args).await }).await
+    into_body(move || f(request.state().clone(), args)).await
 }
 
 /// Registers a `POST` command with the given `path` and execution `f`.


### PR DESCRIPTION
Made the reset + load_initial_state methods public for the sdk.
---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-rs/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
- [x] Checked that changes and commits conform to the standards outlined in [`CONTRIBUTING.md`](https://github.com/manta-network/manta-rs/blob/main/CONTRIBUTING.md).
