### PR TITLE
Bump BIP32 version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [\#331](https://github.com/Manta-Network/manta-rs/pull/331) Merkle tree pruning.
 
 ### Changed
+- [\#342](https://github.com/Manta-Network/manta-rs/pull/342) Bump BIP32 version to 0.4.0.
 
 ### Deprecated
 

--- a/manta-pay/Cargo.toml
+++ b/manta-pay/Cargo.toml
@@ -110,7 +110,7 @@ websocket = [
 [dependencies]
 aes-gcm = { version = "0.9.4", default-features = false, features = ["aes", "alloc"] }
 bip0039 = { version = "0.10.1", optional = true, default-features = false }
-bip32 = { version = "0.3.0", optional = true, default-features = false, features = ["bip39", "secp256k1"] }
+bip32 = { version = "0.4.0", optional = true, default-features = false, features = ["bip39", "secp256k1"] }
 blake2 = { version = "0.10.6", default-features = false }
 bs58 = { version = "0.4.0", optional = true, default-features = false, features = ["alloc"] }
 clap = { version = "4.1.8", optional = true, default-features = false, features = ["color", "derive", "std", "suggestions", "unicode", "wrap_help"] }


### PR DESCRIPTION
Bumps the BIP32 version to 0.4.0.

---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [x] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-rs/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.
- [x] Checked that changes and commits conform to the standards outlined in [`CONTRIBUTING.md`](https://github.com/manta-network/manta-rs/blob/main/CONTRIBUTING.md).
