### PR TITLE
Deprecate pruning feature

### DIFF
--- a/manta-crypto/src/merkle_tree/fork.rs
+++ b/manta-crypto/src/merkle_tree/fork.rs
@@ -19,7 +19,7 @@
 use crate::merkle_tree::{
     capacity,
     inner_tree::{BTreeMap, InnerMap, PartialInnerTree},
-    leaf_map::{LeafMap, LeafVec},
+    leaf_map::{LeafMap, TrivialLeafVec},
     partial::Partial,
     path::{CurrentInnerPath, InnerPath},
     Configuration, CurrentPath, InnerDigest, Leaf, LeafDigest, Node, Parameters, Parity, Path,
@@ -274,7 +274,7 @@ impl Default for BaseContribution {
     Hash(bound = "InnerDigest<C>: Hash, M: Hash, L: Hash"),
     PartialEq(bound = "InnerDigest<C>: PartialEq, M: PartialEq, L: PartialEq")
 )]
-struct Branch<C, M = BTreeMap<C>, L = LeafVec<C>>
+struct Branch<C, M = BTreeMap<C>, L = TrivialLeafVec<C>>
 where
     C: Configuration + ?Sized,
     M: Default + InnerMap<C>,
@@ -587,7 +587,7 @@ where
     Debug(bound = "P::Weak: Debug, L: Debug, InnerDigest<C>: Debug, M: Debug"),
     Default(bound = "L: Default, InnerDigest<C>: Default")
 )]
-pub struct Fork<C, T, P = pointer::SingleThreaded, M = BTreeMap<C>, L = LeafVec<C>>
+pub struct Fork<C, T, P = pointer::SingleThreaded, M = BTreeMap<C>, L = TrivialLeafVec<C>>
 where
     C: Configuration + ?Sized,
     T: Tree<C>,
@@ -839,7 +839,7 @@ where
     Hash(bound = "T: Hash, L: Hash, InnerDigest<C>: Hash, M: Hash"),
     PartialEq(bound = "T: PartialEq, L: PartialEq, InnerDigest<C>: PartialEq, M: PartialEq")
 )]
-pub struct ForkedTree<C, T, M = BTreeMap<C>, L = LeafVec<C>>
+pub struct ForkedTree<C, T, M = BTreeMap<C>, L = TrivialLeafVec<C>>
 where
     C: Configuration + ?Sized,
     T: Tree<C>,

--- a/manta-crypto/src/merkle_tree/partial.rs
+++ b/manta-crypto/src/merkle_tree/partial.rs
@@ -21,7 +21,7 @@
 use crate::merkle_tree::{
     capacity,
     inner_tree::{BTreeMap, InnerMap, InnerNodeIter, PartialInnerTree},
-    leaf_map::{LeafMap, LeafVec},
+    leaf_map::{LeafMap, TrivialLeafVec},
     node::{NodeRange, Parity},
     Configuration, CurrentPath, InnerDigest, Leaf, LeafDigest, MerkleTree, Node, Parameters, Path,
     PathError, Root, Tree, WithProofs,
@@ -57,7 +57,7 @@ pub type PartialMerkleTree<C, M = BTreeMap<C>> = MerkleTree<C, Partial<C, M>>;
     Hash(bound = "L: Hash, InnerDigest<C>: Hash, M: Hash"),
     PartialEq(bound = "L: PartialEq, InnerDigest<C>: PartialEq, M: PartialEq")
 )]
-pub struct Partial<C, M = BTreeMap<C>, L = LeafVec<C>>
+pub struct Partial<C, M = BTreeMap<C>, L = TrivialLeafVec<C>>
 where
     C: Configuration + ?Sized,
     M: InnerMap<C>,

--- a/manta-pay/src/config/utxo.rs
+++ b/manta-pay/src/config/utxo.rs
@@ -25,7 +25,7 @@ use crate::{
         GroupCurve, GroupVar,
     },
     crypto::{
-        encryption::aes,
+        encryption::aes::{self, FixedNonceAesGcm},
         poseidon::{self, encryption::BlockArray, hash::Hasher, ParameterFieldType},
     },
 };
@@ -857,8 +857,7 @@ impl<COM> encryption::Encrypt for IncomingAESEncryptionScheme<COM> {
         plaintext: &Self::Plaintext,
         compiler: &mut (),
     ) -> Self::Ciphertext {
-        let aes = AES::default();
-        aes.encrypt(encryption_key, randomness, header, plaintext, compiler)
+        FixedNonceAesGcm.encrypt(encryption_key, randomness, header, plaintext, compiler)
     }
 }
 
@@ -870,8 +869,7 @@ impl<COM> encryption::Decrypt for IncomingAESEncryptionScheme<COM> {
         ciphertext: &Self::Ciphertext,
         compiler: &mut (),
     ) -> Self::DecryptedPlaintext {
-        let aes = AES::default();
-        aes.decrypt(decryption_key, header, ciphertext, compiler)
+        FixedNonceAesGcm.decrypt(decryption_key, header, ciphertext, compiler)
     }
 }
 
@@ -1610,8 +1608,7 @@ impl<COM> encryption::Encrypt for OutgoingAESEncryptionScheme<COM> {
         plaintext: &Self::Plaintext,
         compiler: &mut (),
     ) -> Self::Ciphertext {
-        let aes = OutAes::default();
-        aes.encrypt(encryption_key, randomness, header, plaintext, compiler)
+        FixedNonceAesGcm.encrypt(encryption_key, randomness, header, plaintext, compiler)
     }
 }
 
@@ -1623,8 +1620,7 @@ impl<COM> encryption::Decrypt for OutgoingAESEncryptionScheme<COM> {
         ciphertext: &Self::Ciphertext,
         compiler: &mut (),
     ) -> Self::DecryptedPlaintext {
-        let aes = OutAes::default();
-        aes.decrypt(decryption_key, header, ciphertext, compiler)
+        FixedNonceAesGcm.decrypt(decryption_key, header, ciphertext, compiler)
     }
 }
 


### PR DESCRIPTION
Temporarily deprecates the pruning feature so existing manta wallet users don't have to restart their wallets triggering the bug.

---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [ ] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-rs/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Checked that changes and commits conform to the standards outlined in [`CONTRIBUTING.md`](https://github.com/manta-network/manta-rs/blob/main/CONTRIBUTING.md).
