### PR TITLE
Nullifier map optimization

### DIFF
--- a/manta-accounting/src/transfer/mod.rs
+++ b/manta-accounting/src/transfer/mod.rs
@@ -169,7 +169,8 @@ pub trait Configuration {
             Secret = Self::SpendSecret,
             Nullifier = Self::Nullifier,
             Identifier = Self::Identifier,
-        > + utxo::UtxoReconstruct;
+        > + utxo::NullifierOpen
+        + utxo::UtxoReconstruct;
 
     /// Authorization Context Variable Type
     type AuthorizationContextVar: Variable<

--- a/manta-accounting/src/transfer/utxo/mod.rs
+++ b/manta-accounting/src/transfer/utxo/mod.rs
@@ -91,6 +91,26 @@ impl IndependenceContext for NullifierIndependence {
     const DEFAULT: bool = false;
 }
 
+/// Nullifier Open
+pub trait NullifierOpen: AssetType + DeriveDecryptionKey + NullifierType {
+    /// Opens the outgoing note in `nullifier` with `decryption_key`.
+    fn open(
+        &self,
+        nullifier: &Self::Nullifier,
+        decryption_key: &Self::DecryptionKey,
+    ) -> Option<Self::Asset>;
+
+    /// Returns `true` if `nullifier` can be opened with `decryption_key`.
+    #[inline]
+    fn can_be_opened(
+        &self,
+        nullifier: &Self::Nullifier,
+        decryption_key: &Self::DecryptionKey,
+    ) -> bool {
+        self.open(nullifier, decryption_key).is_some()
+    }
+}
+
 /// Identifier
 pub trait IdentifierType {
     /// Identifier Type

--- a/manta-accounting/src/transfer/utxo/protocol.rs
+++ b/manta-accounting/src/transfer/utxo/protocol.rs
@@ -1368,6 +1368,31 @@ where
     }
 }
 
+impl<C> utxo::NullifierOpen for Parameters<C>
+where
+    C: Configuration<Bool = bool>,
+    C::OutgoingBaseEncryptionScheme:
+        Decrypt<DecryptionKey = C::Group, DecryptedPlaintext = Option<Asset<C>>>,
+{
+    #[inline]
+    fn open(
+        &self,
+        nullifier: &Self::Nullifier,
+        decryption_key: &Self::DecryptionKey,
+    ) -> Option<Self::Asset> {
+        Hybrid::new(
+            StandardDiffieHellman::new(self.base.group_generator.generator().clone()),
+            self.base.outgoing_base_encryption_scheme.clone(),
+        )
+        .decrypt(
+            decryption_key,
+            &C::OutgoingHeader::default(),
+            &nullifier.outgoing_note.ciphertext,
+            &mut (),
+        )
+    }
+}
+
 impl<C> utxo::NoteOpen for Parameters<C>
 where
     C: Configuration<Bool = bool>,

--- a/manta-accounting/src/wallet/signer/nullifier_map.rs
+++ b/manta-accounting/src/wallet/signer/nullifier_map.rs
@@ -43,6 +43,9 @@ pub trait NullifierMap<T>: Default {
     where
         I: IntoIterator<Item = T>;
 
+    /// Removes `item` from `self`.
+    fn remove(&mut self, item: &T) -> bool;
+
     /// Checks if `self` contains `item`.
     fn contains_item(&self, item: &T) -> bool;
 }
@@ -73,6 +76,16 @@ where
         I: IntoIterator<Item = T>,
     {
         Extend::extend(self, items)
+    }
+
+    #[inline]
+    fn remove(&mut self, item: &T) -> bool {
+        if let Some(index) = self.iter().position(|x| x == item) {
+            self.remove(index);
+            true
+        } else {
+            false
+        }
     }
 
     #[inline]
@@ -109,6 +122,11 @@ where
     }
 
     #[inline]
+    fn remove(&mut self, item: &T) -> bool {
+        self.remove(item)
+    }
+
+    #[inline]
     fn contains_item(&self, item: &T) -> bool {
         self.contains(item)
     }
@@ -140,6 +158,11 @@ where
         I: IntoIterator<Item = T>,
     {
         Extend::extend(self, items)
+    }
+
+    #[inline]
+    fn remove(&mut self, item: &T) -> bool {
+        self.remove(item)
     }
 
     #[inline]

--- a/manta-pay/src/lib.rs
+++ b/manta-pay/src/lib.rs
@@ -33,8 +33,8 @@ pub mod config;
 #[cfg_attr(doc_cfg, doc(cfg(feature = "key")))]
 pub mod key;
 
-#[cfg(all(feature = "parameters"))]
-#[cfg_attr(doc_cfg, doc(cfg(all(feature = "parameters"))))]
+#[cfg(feature = "parameters")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "parameters")))]
 pub mod parameters;
 
 #[cfg(feature = "groth16")]


### PR DESCRIPTION
Frees the signer memory from holding every nullifier. Now it only holds the user's nullifiers if they haven't been spent yet. 

---

Before we can merge this PR, please make sure that all the following items have been checked off:

- [ ] Linked to an issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Added **one** line describing your change in [`CHANGELOG.md`](https://github.com/manta-network/manta-rs/blob/main/CHANGELOG.md) and added the appropriate `changelog` label to the PR.
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Checked that changes and commits conform to the standards outlined in [`CONTRIBUTING.md`](https://github.com/manta-network/manta-rs/blob/main/CONTRIBUTING.md).
